### PR TITLE
Add Import of Origin licenses to DateImporter

### DIFF
--- a/source/Generic/DateImporter/DateImporter.psm1
+++ b/source/Generic/DateImporter/DateImporter.psm1
@@ -948,7 +948,7 @@ function Get-OriginLicenses
 
     $jsonValid = Get-IsJsonValidFromPage $pageSource
 
-    if($jsonValid -eq $false) 
+    if ($jsonValid -eq $false) 
     {
         $PlayniteApi.Dialogs.ShowMessage([Playnite.SDK.ResourceProvider]::GetString("LOCDate_Importer_MenuItemImportOriginInvalidJson"), "$libraryName Date Importer")
         return $LicensesList
@@ -989,7 +989,7 @@ function Get-OriginLicenses
     $licenses = Select-Xml $xml -XPath '/entitlements/entitlement'
     foreach ($license in $licenses) {
         $type = $license.Node.offer.offerType.ToLower() -replace " ", ""
-        if($($type -eq "basegame") -or $($type -eq "demo")) 
+        if ($($type -eq "basegame") -or $($type -eq "demo")) 
         {
             $date = Get-Date $license.Node.grantDate
             $product = [PSCustomObject]@{

--- a/source/Generic/DateImporter/DateImporter.psm1
+++ b/source/Generic/DateImporter/DateImporter.psm1
@@ -966,6 +966,8 @@ function Get-OriginLicenses
     try {
         $idResponse = Invoke-RestMethod -Method "GET" -Uri $idUrl -Headers $headers -ContentType "application/json" -UseBasicParsing
     } catch {
+        $errorMessage = $_.Exception.Message
+        $__logger.Info("Error retrieving user id from Origin. Uri: $idUrl,  Error: $errorMessage")
         $PlayniteApi.Dialogs.ShowMessage([Playnite.SDK.ResourceProvider]::GetString("LOCDate_Importer_MenuItemImportOriginErrorMessage"), "$libraryName Date Importer")
         return $LicensesList
     }
@@ -981,6 +983,8 @@ function Get-OriginLicenses
     try {
         $xml = Invoke-RestMethod -Method "GET" -Uri $licenseUrl -Headers $headers -ContentType "application/xml" -UseBasicParsing
     } catch {
+        $errorMessage = $_.Exception.Message
+        $__logger.Info("Error retrieving license data from Origin. Uri: $licenseUrl,  Error: $errorMessage")
         $PlayniteApi.Dialogs.ShowMessage([Playnite.SDK.ResourceProvider]::GetString("LOCDate_Importer_MenuItemImportOriginErrorMessage"), "$libraryName Date Importer")
         return $LicensesList
     }

--- a/source/Generic/DateImporter/DateImporter.psm1
+++ b/source/Generic/DateImporter/DateImporter.psm1
@@ -948,7 +948,8 @@ function Get-OriginLicenses
 
     $jsonValid = Get-IsJsonValidFromPage $pageSource
 
-    if($jsonValid -eq $false) {
+    if($jsonValid -eq $false) 
+    {
         $PlayniteApi.Dialogs.ShowMessage([Playnite.SDK.ResourceProvider]::GetString("LOCDate_Importer_MenuItemImportOriginInvalidJson"), "$libraryName Date Importer")
         return $LicensesList
     }

--- a/source/Generic/DateImporter/DateImporter.psm1
+++ b/source/Generic/DateImporter/DateImporter.psm1
@@ -964,7 +964,7 @@ function Get-OriginLicenses
     }
     $idResponse = $null
     try {
-        $idResponse = Invoke-RestMethod -Method "GET" -Uri $idUrl -Headers $headers -ContentType "application/json"
+        $idResponse = Invoke-RestMethod -Method "GET" -Uri $idUrl -Headers $headers -ContentType "application/json" -UseBasicParsing
     } catch {
         $PlayniteApi.Dialogs.ShowMessage([Playnite.SDK.ResourceProvider]::GetString("LOCDate_Importer_MenuItemImportOriginErrorMessage"), "$libraryName Date Importer")
         return $LicensesList
@@ -979,7 +979,7 @@ function Get-OriginLicenses
     }
     $xml = $null
     try {
-        $xml = Invoke-RestMethod -Method "GET" -Uri $licenseUrl -Headers $headers -ContentType "application/xml"
+        $xml = Invoke-RestMethod -Method "GET" -Uri $licenseUrl -Headers $headers -ContentType "application/xml" -UseBasicParsing
     } catch {
         $PlayniteApi.Dialogs.ShowMessage([Playnite.SDK.ResourceProvider]::GetString("LOCDate_Importer_MenuItemImportOriginErrorMessage"), "$libraryName Date Importer")
         return $LicensesList

--- a/source/Generic/DateImporter/Localization/en_US.xaml
+++ b/source/Generic/DateImporter/Localization/en_US.xaml
@@ -11,7 +11,12 @@
     <sys:String x:Key="LOCDate_Importer_MenuItemImportSelectedEpicDatesDescription">Import dates of selected Epic games</sys:String>
     <sys:String x:Key="LOCDate_Importer_MenuItemImportAllEpicDatesDescription">Import dates of all Epic games</sys:String>
     <sys:String x:Key="LOCDate_Importer_MenuItemExportEpicLicencesDescription">Export Epic licenses list</sys:String>
-    <sys:String x:Key="LOCDate_Importer_LoginNotifyMessage">A web browser window will be opened, please close the window after login in.</sys:String>
+	<sys:String x:Key="LOCDate_Importer_MenuItemImportSelectedOriginDatesDescription">Import dates of selected Origin games</sys:String>
+	<sys:String x:Key="LOCDate_Importer_MenuItemImportAllOriginDatesDescription">Import dates of all Origin games</sys:String>
+	<sys:String x:Key="LOCDate_Importer_MenuItemImportOriginErrorMessage">Error retrieving data from Origin</sys:String>
+	<sys:String x:Key="LOCDate_Importer_MenuItemImportOriginInvalidJson">Origin data is invalid</sys:String>
+	<sys:String x:Key="LOCDate_Importer_MenuItemExportOriginLicencesDescription">Export Origin licenses list</sys:String>
+	<sys:String x:Key="LOCDate_Importer_LoginNotifyMessage">A web browser window will be opened, please close the window after login in.</sys:String>
     <sys:String x:Key="LOCDate_Importer_LicensesNotFoundMessage">No licenses were found.</sys:String>
     <sys:String x:Key="LOCDate_Importer_LicensesExportChoiceMessage" xml:space="preserve">Found {0} licenses.
 Do you want to export your found {1} licenses?</sys:String>

--- a/source/Generic/DateImporter/Localization/en_US.xaml
+++ b/source/Generic/DateImporter/Localization/en_US.xaml
@@ -11,12 +11,12 @@
     <sys:String x:Key="LOCDate_Importer_MenuItemImportSelectedEpicDatesDescription">Import dates of selected Epic games</sys:String>
     <sys:String x:Key="LOCDate_Importer_MenuItemImportAllEpicDatesDescription">Import dates of all Epic games</sys:String>
     <sys:String x:Key="LOCDate_Importer_MenuItemExportEpicLicencesDescription">Export Epic licenses list</sys:String>
-	<sys:String x:Key="LOCDate_Importer_MenuItemImportSelectedOriginDatesDescription">Import dates of selected Origin games</sys:String>
-	<sys:String x:Key="LOCDate_Importer_MenuItemImportAllOriginDatesDescription">Import dates of all Origin games</sys:String>
-	<sys:String x:Key="LOCDate_Importer_MenuItemImportOriginErrorMessage">Error retrieving data from Origin</sys:String>
-	<sys:String x:Key="LOCDate_Importer_MenuItemImportOriginInvalidJson">Origin data is invalid</sys:String>
-	<sys:String x:Key="LOCDate_Importer_MenuItemExportOriginLicencesDescription">Export Origin licenses list</sys:String>
-	<sys:String x:Key="LOCDate_Importer_LoginNotifyMessage">A web browser window will be opened, please close the window after login in.</sys:String>
+    <sys:String x:Key="LOCDate_Importer_MenuItemImportSelectedOriginDatesDescription">Import dates of selected Origin games</sys:String>
+    <sys:String x:Key="LOCDate_Importer_MenuItemImportAllOriginDatesDescription">Import dates of all Origin games</sys:String>
+    <sys:String x:Key="LOCDate_Importer_MenuItemImportOriginErrorMessage">Error retrieving data from Origin</sys:String>
+    <sys:String x:Key="LOCDate_Importer_MenuItemImportOriginInvalidJson">Origin data is invalid</sys:String>
+    <sys:String x:Key="LOCDate_Importer_MenuItemExportOriginLicencesDescription">Export Origin licenses list</sys:String>
+    <sys:String x:Key="LOCDate_Importer_LoginNotifyMessage">A web browser window will be opened, please close the window after login in.</sys:String>
     <sys:String x:Key="LOCDate_Importer_LicensesNotFoundMessage">No licenses were found.</sys:String>
     <sys:String x:Key="LOCDate_Importer_LicensesExportChoiceMessage" xml:space="preserve">Found {0} licenses.
 Do you want to export your found {1} licenses?</sys:String>

--- a/source/Generic/DateImporter/Localization/en_US.xaml
+++ b/source/Generic/DateImporter/Localization/en_US.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
-    <sys:String x:Key="LOCDate_Importer_MenuItemImportSelectedDescription">Import dates of selected Epic, GOG and Steam games</sys:String>
-    <sys:String x:Key="LOCDate_Importer_MenuItemImportAllDescription">Import dates of all Epic, GOG and Steam games</sys:String>
+    <sys:String x:Key="LOCDate_Importer_MenuItemImportSelectedDescription">Import dates of selected Epic, GOG, Origin and Steam games</sys:String>
+    <sys:String x:Key="LOCDate_Importer_MenuItemImportAllDescription">Import dates of all Epic, GOG, Origin and Steam games</sys:String>
     <sys:String x:Key="LOCDate_Importer_MenuItemSetDateManualDescription">Set added date of selected games manually</sys:String>
     <sys:String x:Key="LOCDate_Importer_MenuItemImportSelectedSteamDatesDescription">Import dates of selected Steam games</sys:String>
     <sys:String x:Key="LOCDate_Importer_MenuItemImportAllSteamDatesDescription">Import dates of all Steam games</sys:String>


### PR DESCRIPTION
Added functionality for import Origin licenses. 

I oriented my code on what was used in the existing importers. The logic for retrieving the data from Origin was straight up stolen from Crow himself (https://github.com/JosefNemec/PlayniteExtensions/blob/9ec2f43a17f93707cfa39d6b4056a9459852a8fa/source/Libraries/OriginLibrary/Services/OriginAccountClient.cs) 😄 
When fetching the data from Origin only games and demos are considered, dlc or ingame purchases are filtered out before using your logic for processing the licenses.

I also added two new translation strings apart from the default ones for new importers:
- LOCDate_Importer_MenuItemImportOriginInvalidJson: for invalid json from Origin
- LOCDate_Importer_MenuItemImportOriginErrorMessage: for connection errors in the subsequent REST calls for retrieving the license data

There are apparently some games for which it will not work. For me it was Mass Effect 2/3 which have the release date included in the name in the Origin response so the name matching didn't work. I did fix this as it was only two games out of 45 for me and the user get the result export in the end anyway. I thought i would rather leave the code more simple than try to implement some complicated name matching. Hope thats ok 😄 