### PR TITLE
Extra Metadata tools Video: Add download by youtube id

### DIFF
--- a/source/Generic/ExtraMetadataToolsVideo/ExtraMetadataToolsVideo.psm1
+++ b/source/Generic/ExtraMetadataToolsVideo/ExtraMetadataToolsVideo.psm1
@@ -48,7 +48,7 @@ function GetGameMenuItems
     $menuItem9.Description =  [Playnite.SDK.ResourceProvider]::GetString("LOCExtra_Metadata_tools_MenuItemSet-YouTubeVideoDescription")
     $menuItem9.FunctionName = "Set-YouTubeVideo"
     $menuItem9.MenuSection = "Extra Metadata tools|Video|Trailers"
-    
+	
     $menuItem10 = New-Object Playnite.SDK.Plugins.ScriptGameMenuItem
     $menuItem10.Description =  [Playnite.SDK.ResourceProvider]::GetString("LOCExtra_Metadata_tools_MenuItemInvoke-YoutubeSearchWindowDescription")
     $menuItem10.FunctionName = "Invoke-YoutubeSearchWindow"
@@ -59,7 +59,12 @@ function GetGameMenuItems
     $menuItem11.FunctionName = "Update-AssetsStatusGameDatabase"
     $menuItem11.MenuSection = "Extra Metadata tools"
 
-    return $menuItem, $menuItem2, $menuItem3, $menuItem9, $menuItem10, $menuItem4, $menuItem5, $menuItem6, $menuItem7, $menuItem8, $menuItem11
+    $menuItem12 = New-Object Playnite.SDK.Plugins.ScriptGameMenuItem
+    $menuItem12.Description =  [Playnite.SDK.ResourceProvider]::GetString("LOCExtra_Metadata_tools_MenuItemSet-YouTubeVideoId")
+    $menuItem12.FunctionName = "Set-YouTubeVideoID"
+    $menuItem12.MenuSection = "Extra Metadata tools|Video|Trailers"
+    
+    return $menuItem, $menuItem2, $menuItem3, $menuItem9, $menuItem10, $menuItem12, $menuItem4, $menuItem5, $menuItem6, $menuItem7, $menuItem8, $menuItem11
 }
 
 function Get-MandatorySettingsList
@@ -814,6 +819,23 @@ function Remove-DownloadedVideos
     # Update assets status of collection
     Update-CollectionExtraAssetsStatus $gameDatabase $false
     $PlayniteApi.Dialogs.ShowMessage(("Done.`n`nDeleted videos: {0}" -f $deletedVideos.ToString()), "Extra Metadata Tools")
+}
+
+function Set-YouTubeVideoID
+{
+    param(
+        $scriptGameMenuItemActionArgs
+    )
+
+    $Result = $PlayniteApi.Dialogs.SelectString([Playnite.SDK.ResourceProvider]::GetString("LOCExtra_Metadata_tools_EnterYoutubeIdMessage"), "Extra Metadata Tools", "")
+
+    if($Result.result)
+    {
+        if ($Result.selectedString -ne "")
+        {
+            Set-YouTubeVideoManual $Result.selectedString
+        }
+    }
 }
 
 function Set-YouTubeVideo

--- a/source/Generic/ExtraMetadataToolsVideo/ExtraMetadataToolsVideo.psm1
+++ b/source/Generic/ExtraMetadataToolsVideo/ExtraMetadataToolsVideo.psm1
@@ -829,7 +829,7 @@ function Set-YouTubeVideoID
 
     $Result = $PlayniteApi.Dialogs.SelectString([Playnite.SDK.ResourceProvider]::GetString("LOCExtra_Metadata_tools_EnterYoutubeIdMessage"), "Extra Metadata Tools", "")
 
-    if($Result.result)
+    if ($Result.result)
     {
         if ($Result.selectedString -ne "")
         {

--- a/source/Generic/ExtraMetadataToolsVideo/ExtraMetadataToolsVideo.psm1
+++ b/source/Generic/ExtraMetadataToolsVideo/ExtraMetadataToolsVideo.psm1
@@ -827,13 +827,13 @@ function Set-YouTubeVideoID
         $scriptGameMenuItemActionArgs
     )
 
-    $Result = $PlayniteApi.Dialogs.SelectString([Playnite.SDK.ResourceProvider]::GetString("LOCExtra_Metadata_tools_EnterYoutubeIdMessage"), "Extra Metadata Tools", "")
+    $result = $PlayniteApi.Dialogs.SelectString([Playnite.SDK.ResourceProvider]::GetString("LOCExtra_Metadata_tools_EnterYoutubeIdMessage"), "Extra Metadata Tools", "")
 
-    if ($Result.result)
+    if ($result.result)
     {
-        if ($Result.selectedString -ne "")
+        if ($result.selectedString -ne "")
         {
-            Set-YouTubeVideoManual $Result.selectedString
+            Set-YouTubeVideoManual $result.selectedString
         }
     }
 }

--- a/source/Generic/ExtraMetadataToolsVideo/ExtraMetadataToolsVideo.psm1
+++ b/source/Generic/ExtraMetadataToolsVideo/ExtraMetadataToolsVideo.psm1
@@ -829,11 +829,11 @@ function Set-YouTubeVideoID
 
     $result = $PlayniteApi.Dialogs.SelectString([Playnite.SDK.ResourceProvider]::GetString("LOCExtra_Metadata_tools_EnterYoutubeIdMessage"), "Extra Metadata Tools", "")
 
-    if ($result.result)
+    if ($result.Result)
     {
-        if ($result.selectedString -ne "")
+        if ($result.SelectedString -ne "")
         {
-            Set-YouTubeVideoManual $result.selectedString
+            Set-YouTubeVideoManual $result.SelectedString
         }
     }
 }

--- a/source/Generic/ExtraMetadataToolsVideo/Localization/en_US.xaml
+++ b/source/Generic/ExtraMetadataToolsVideo/Localization/en_US.xaml
@@ -9,6 +9,7 @@
     <sys:String x:Key="LOCExtra_Metadata_tools_MenuItemRemove-VideoMicrotrailerDescription">Delete microtrailer video of the selected game(s)</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_tools_MenuItemSet-YouTubeVideoDescription">[YouTube] Auto download YouTube trailer video for selected games</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_tools_MenuItemInvoke-YoutubeSearchWindowDescription">[YouTube] Search YouTube video for the selected game</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_tools_MenuItemSet-YouTubeVideoId">[YouTube] Download by YouTube video id for the selected game</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_tools_MenuItemUpdate-AssetsStatusGameDatabaseDescription">Update assets status tags of all games in database</sys:String>
 
     <sys:String x:Key="LOCExtra_Metadata_tools_SelectFfmpegExecutableMessage">Select ffmpeg executable.</sys:String>
@@ -20,4 +21,5 @@
     <sys:String x:Key="LOCExtra_Metadata_tools_MoreThanSingleGameSelectedMessage">More than one game is selected, please select only one game.</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_tools_GenericFinishedMessage">Finished.</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_tools_GenericErrorProcessingFileMessage">Selected file could not be processed.</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_tools_EnterYoutubeIdMessage">Please enter the YouTube video id.</sys:String>
 </ResourceDictionary>


### PR DESCRIPTION
I sometimes search for a trailer video on youtube if i can't find a good result in the few videos it shows in the plugin but i have no easy way to download these except by first manually downloading the video using youtube-dl and then assigning using local file. This extra feature goes around this problem by directly downloading a youtube video if you provide the video id, saves me the hassle of first having to download it myself manually