### PR TITLE
Added temporary workaround for sharing paused time

### DIFF
--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -599,7 +599,7 @@ namespace PlayState
             // This method will remove the info of the txt file in order to avoid reusing the previous play information.
             string[] info = { " ", " " };
 
-            File.WriteAllLines(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Playnite", "ExtensionsData", "PlayState.txt"), info);
+            File.WriteAllLines(Path.Combine(PlayniteApi.Paths.ExtensionsDataPath, "PlayState.txt"), info);
         }
 
         private void ExportPausedTimeInfo(Game game, ulong elapsedSeconds) // Temporary workaround for sharing PlayState paused time until Playnite allows to share data among extensions
@@ -607,7 +607,7 @@ namespace PlayState
             // This method will write the Id and pausedTime to PlayState.txt file placed inside ExtensionsData Roaming Playnite folder
             string[] info = { game.Id.ToString(), elapsedSeconds.ToString() };
 
-            File.WriteAllLines(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Playnite", "ExtensionsData", "PlayState.txt"), info);
+            File.WriteAllLines(Path.Combine(PlayniteApi.Paths.ExtensionsDataPath, "PlayState.txt"), info);
         }
 
         public override IEnumerable<MainMenuItem> GetMainMenuItems(GetMainMenuItemsArgs args)

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -228,6 +228,8 @@ namespace PlayState
 
         public override void OnGameStarted(OnGameStartedEventArgs args)
         {
+            InitializePlaytimeInfoFile(); // Temporary workaround for sharing PlayState paused time until Playnite allows to share data among extensions
+
             if (isSuspended)
             {
                 SwitchGameState();
@@ -554,6 +556,7 @@ namespace PlayState
                     {
                         var elapsedSeconds = Convert.ToUInt64(suspendedTime.Value.TotalSeconds);
                         logger.Debug($"Suspend elapsed seconds for game {game.Name} was {elapsedSeconds}");
+                        ExportPausedTimeInfo(game, elapsedSeconds); // Temporary workaround for sharing PlayState paused time until Playnite allows to share data among extensions
                         if (elapsedSeconds != 0)
                         {
                             var newPlaytime = game.Playtime > elapsedSeconds ? game.Playtime - elapsedSeconds : elapsedSeconds - game.Playtime;
@@ -589,6 +592,22 @@ namespace PlayState
                 stopwatchList.Remove(tuple);
                 logger.Debug($"Stopwatch for game {game.Name} with id {game.Id} was removed on game stopped");
             }
+        }
+
+        private void InitializePlaytimeInfoFile() // Temporary workaround for sharing PlayState paused time until Playnite allows to share data among extensions
+        {
+            // This method will remove the info of the txt file in order to avoid reusing the previous play information.
+            string[] info = { " ", " " };
+
+            File.WriteAllLines(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Playnite", "ExtensionsData", "PlayState.txt"), info);
+        }
+
+        private void ExportPausedTimeInfo(Game game, ulong elapsedSeconds) // Temporary workaround for sharing PlayState paused time until Playnite allows to share data among extensions
+        {
+            // This method will write the Id and pausedTime to PlayState.txt file placed inside ExtensionsData Roaming Playnite folder
+            string[] info = { game.Id.ToString(), elapsedSeconds.ToString() };
+
+            File.WriteAllLines(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Playnite", "ExtensionsData", "PlayState.txt"), info);
         }
 
         public override IEnumerable<MainMenuItem> GetMainMenuItems(GetMainMenuItemsArgs args)


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.

This PR is linked to this PR of GameActivity extension: https://github.com/Lacro59/playnite-gameactivity-plugin/pull/119

Temporary workaround for #122

I used the simple code as possible since this is only a temporary workaround until Playnite allows to share data among extensions.

The file is placed inside AppData/Roaming/Playnite/ExtensionsData folder with the name of "PlayState.txt". This file will be cleaned after executing one game or retrieving the info on GameActivity plugin in order to avoid reusing the same information over and over again if PlayState gets uninstalled or is not working for any reason.

I added as much code as possible in new methods, notes for explaining the functioning and a annotation that says:

> // Temporary workaround for sharing PlayState paused time until Playnite allows to share data among extensions

In order to ease the removal in the future when another better method is available.

EDIT: I forgot to mention, I tested the extension manually replacing the compiled files, I didn't achieve to create the pext file.