### PR TITLE
PlayState: Add Windows notifications

### DIFF
--- a/source/Generic/PlayState/Enums/NotificationTypes.cs
+++ b/source/Generic/PlayState/Enums/NotificationTypes.cs
@@ -1,0 +1,11 @@
+﻿namespace PlayState.Enums
+{
+    public enum NotificationTypes
+    {
+        Resumed = 1,
+        PlaytimeResumed = 2,
+        Suspended = 3,
+        PlaytimeSuspended = 4,
+        Information = 5,
+    }
+}

--- a/source/Generic/PlayState/Localization/en_US.xaml
+++ b/source/Generic/PlayState/Localization/en_US.xaml
@@ -3,8 +3,6 @@
     <sys:String x:Key="LOCPlayState_MenuItemRemoveFromBlacklistDescription">Remove selected games from Playstate Blacklist</sys:String>
     <sys:String x:Key="LOCPlayState_MenuItemAddToPlaytimeSuspendDescription">Configure selected games to force to only suspend playtime</sys:String>
     <sys:String x:Key="LOCPlayState_MenuItemRemoveFromPlaytimeSuspendDescription">Remove configuration to force to only suspend playtime</sys:String>
-    <sys:String x:Key="LOCPlayState_MenuItemAddToWindowsNotificationsStyleDescription">Configure selected games to force to show Windows notifications</sys:String>
-    <sys:String x:Key="LOCPlayState_MenuItemRemoveFromWindowsNotificationsStyleDescription">Remove configuration to force to show Windows notifications</sys:String>
     <sys:String x:Key="LOCPlayState_NotificationMessageHotkeyRegisterFailed" xml:space="preserve">Failed to register configured Hotkey {0}
 
 You can try using a diferent HotKey combination to possibly fix the issue</sys:String>
@@ -14,10 +12,6 @@ You can try using a diferent HotKey combination to possibly fix the issue</sys:S
     <sys:String x:Key="LOCPlayState_PlaytimeSuspendRemovedResultsMessage" xml:space="preserve">Removed configuration to force to only suspend playtime when using the configured hotkey from {0} game(s).
 
 Games will be suspended when using the configured hotkey.</sys:String>
-    <sys:String x:Key="LOCPlayState_WindowsNotificationsStyleAddedResultsMessage">Configured {0} game(s) to force to show Windows notifications instead Playnite overlay.</sys:String>
-    <sys:String x:Key="LOCPlayState_WindowsNotificationsStyleRemovedResultsMessage" xml:space="preserve">Removed configuration to force to show Windows notifications from {0} game(s).
-
-Notifications will be send using Playnite overlay.</sys:String>
     <sys:String x:Key="LOCPlayState_StatusSuspendedMessage">Game suspended</sys:String>
     <sys:String x:Key="LOCPlayState_StatusResumedMessage">Game resumed</sys:String>
     <sys:String x:Key="LOCPlayState_StatusPlaytimeSuspendedMessage">Playtime suspended</sys:String>
@@ -39,9 +33,7 @@ If you have Focus Assist enabled when playing a game, you have to add Playnite t
     
 This can also be applied individually per game by adding a feature named "[PlayState] Suspend playtime only" to a game</sys:String>
     <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleLabel">Show Windows notifications instead Playnite overlay</sys:String>
-    <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleTooltip" xml:space="preserve">By enabling this option, all games will show Windows toast notifications instead Playnite overlay notifications.
-    
-This can also be applied individually per game by adding a feature named "[PlayState] Show Windows notifications style" to a game</sys:String>
+    <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleTooltip" xml:space="preserve">By enabling this option, games will show Windows toast notifications instead Playnite overlay notifications.</sys:String>
     <sys:String x:Key="LOCPlayState_Playtime">Playtime:</sys:String>
     <sys:String x:Key="LOCPlayState_TotalPlaytime">Total playtime:</sys:String>
     <sys:String x:Key="LOCPlayState_HoursMinutesPlayed">{0} hours {1} minutes</sys:String>

--- a/source/Generic/PlayState/Localization/en_US.xaml
+++ b/source/Generic/PlayState/Localization/en_US.xaml
@@ -32,8 +32,8 @@ If you have Focus Assist enabled when playing a game, you have to add Playnite t
     <sys:String x:Key="LOCPlayState_SettingGlobalOnlySuspendPlaytimeTooltip" xml:space="preserve">By enabling this option, all games won't be suspended when using the configured hotkey and only the time will be counted to substracted from the game playtime when it stops.
     
 This can also be applied individually per game by adding a feature named "[PlayState] Suspend playtime only" to a game</sys:String>
-    <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleLabel">Show Windows notifications instead Playnite overlay</sys:String>
-    <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleTooltip" xml:space="preserve">By enabling this option, games will show Windows toast notifications instead Playnite overlay notifications.</sys:String>
+    <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleLabel">Show native Windows notifications instead of Playnite notification window</sys:String>
+    <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleTooltip">By enabling this option, games will show native Windows notifications instead of Playnite notification window.</sys:String>
     <sys:String x:Key="LOCPlayState_Playtime">Playtime:</sys:String>
     <sys:String x:Key="LOCPlayState_TotalPlaytime">Total playtime:</sys:String>
     <sys:String x:Key="LOCPlayState_HoursMinutesPlayed">{0} hours {1} minutes</sys:String>

--- a/source/Generic/PlayState/Localization/en_US.xaml
+++ b/source/Generic/PlayState/Localization/en_US.xaml
@@ -3,6 +3,8 @@
     <sys:String x:Key="LOCPlayState_MenuItemRemoveFromBlacklistDescription">Remove selected games from Playstate Blacklist</sys:String>
     <sys:String x:Key="LOCPlayState_MenuItemAddToPlaytimeSuspendDescription">Configure selected games to force to only suspend playtime</sys:String>
     <sys:String x:Key="LOCPlayState_MenuItemRemoveFromPlaytimeSuspendDescription">Remove configuration to force to only suspend playtime</sys:String>
+    <sys:String x:Key="LOCPlayState_MenuItemAddToWindowsNotificationsStyleDescription">Configure selected games to force to show Windows notifications</sys:String>
+    <sys:String x:Key="LOCPlayState_MenuItemRemoveFromWindowsNotificationsStyleDescription">Remove configuration to force to show Windows notifications</sys:String>
     <sys:String x:Key="LOCPlayState_NotificationMessageHotkeyRegisterFailed" xml:space="preserve">Failed to register configured Hotkey {0}
 
 You can try using a diferent HotKey combination to possibly fix the issue</sys:String>
@@ -12,17 +14,23 @@ You can try using a diferent HotKey combination to possibly fix the issue</sys:S
     <sys:String x:Key="LOCPlayState_PlaytimeSuspendRemovedResultsMessage" xml:space="preserve">Removed configuration to force to only suspend playtime when using the configured hotkey from {0} game(s).
 
 Games will be suspended when using the configured hotkey.</sys:String>
+    <sys:String x:Key="LOCPlayState_WindowsNotificationsStyleAddedResultsMessage">Configured {0} game(s) to force to show Windows notifications instead Playnite overlay.</sys:String>
+    <sys:String x:Key="LOCPlayState_WindowsNotificationsStyleRemovedResultsMessage" xml:space="preserve">Removed configuration to force to show Windows notifications from {0} game(s).
+
+Notifications will be send using Playnite overlay.</sys:String>
     <sys:String x:Key="LOCPlayState_StatusSuspendedMessage">Game suspended</sys:String>
     <sys:String x:Key="LOCPlayState_StatusResumedMessage">Game resumed</sys:String>
     <sys:String x:Key="LOCPlayState_StatusPlaytimeSuspendedMessage">Playtime suspended</sys:String>
     <sys:String x:Key="LOCPlayState_StatusPlaytimeResumedMessage">Playtime resumed</sys:String>
     <sys:String x:Key="LOCPlayState_SettingConfiguredHotkeyLabel">Configured Suspend/Resume hotkey:</sys:String>
+    <sys:String x:Key="LOCPlayState_SettingConfiguredInformationHotkeyLabel">Configured Information hotkey:</sys:String>
     <sys:String x:Key="LOCPlayState_SettingChangeHotkeyButtonLabel">Change Hotkey</sys:String>
     <sys:String x:Key="LOCPlayState_SettingPressHotkeyPromtButtonLabel">Press Hotkey now</sys:String>
     <sys:String x:Key="LOCPlayState_SettingNotes" xml:space="preserve">Notes:
 
 Configured hotkey won't be able to be used in other applications.
-Changing this setting requires restart.</sys:String>
+Changing this setting requires restart.
+If you have Focus Assist enabled when playing a game, you have to add Playnite to priority list in order to receive Windows notifications.</sys:String>
     <sys:String x:Key="LOCPlayState_SettingSubstractSuspendedPlaytimeOnStoppedLabel">Substract the time the game was suspended from the game playtime when it is stopped</sys:String>
     <sys:String x:Key="LOCPlayState_SettingSubstractSuspendedPlaytimeOnStoppedTooltip">Helps to keep a more accurate playtime value in games by only keeping the time the game was not suspended count towards the game playtime</sys:String>
     <sys:String x:Key="LOCPlayState_SettingSubstractOnlyNonLibraryGamesLabel">Only execute for games that are not managed by library plugins</sys:String>
@@ -30,4 +38,16 @@ Changing this setting requires restart.</sys:String>
     <sys:String x:Key="LOCPlayState_SettingGlobalOnlySuspendPlaytimeTooltip" xml:space="preserve">By enabling this option, all games won't be suspended when using the configured hotkey and only the time will be counted to substracted from the game playtime when it stops.
     
 This can also be applied individually per game by adding a feature named "[PlayState] Suspend playtime only" to a game</sys:String>
+    <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleLabel">Show Windows notifications instead Playnite overlay</sys:String>
+    <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleTooltip" xml:space="preserve">By enabling this option, all games will show Windows toast notifications instead Playnite overlay notifications.
+    
+This can also be applied individually per game by adding a feature named "[PlayState] Show Windows notifications style" to a game</sys:String>
+    <sys:String x:Key="LOCPlayState_Playtime">Playtime:</sys:String>
+    <sys:String x:Key="LOCPlayState_TotalPlaytime">Total playtime:</sys:String>
+    <sys:String x:Key="LOCPlayState_HoursMinutesPlayed">{0} hours {1} minutes</sys:String>
+    <sys:String x:Key="LOCPlayState_HoursMinutePlayed">{0} hours {1} minute</sys:String>
+    <sys:String x:Key="LOCPlayState_HourMinutesPlayed">{0} hour {1} minutes</sys:String>
+    <sys:String x:Key="LOCPlayState_HourMinutePlayed">{0} hour {1} minute</sys:String>
+    <sys:String x:Key="LOCPlayState_SecondsPlayed">{0} seconds</sys:String>
+    <sys:String x:Key="LOCPlayState_SecondPlayed">{0} second</sys:String>
 </ResourceDictionary>

--- a/source/Generic/PlayState/Models/PlayStateData.cs
+++ b/source/Generic/PlayState/Models/PlayStateData.cs
@@ -1,0 +1,24 @@
+﻿using Playnite.SDK.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PlayState.Models
+{
+    public class PlayStateData
+    {
+        public Game Game { get; set; }
+        public DateTime StartDate { get; set; }
+        public Stopwatch Stopwatch { get; set; }
+
+        public PlayStateData(Game game, DateTime startDate, Stopwatch stopwatch)
+        {
+            Game = game;
+            StartDate = startDate;
+            Stopwatch = stopwatch;
+        }
+    }
+}

--- a/source/Generic/PlayState/Models/PlayStateData.cs
+++ b/source/Generic/PlayState/Models/PlayStateData.cs
@@ -14,11 +14,11 @@ namespace PlayState.Models
         public DateTime StartDate { get; set; }
         public Stopwatch Stopwatch { get; set; }
 
-        public PlayStateData(Game game, DateTime startDate, Stopwatch stopwatch)
+        public PlayStateData(Game game)
         {
             Game = game;
-            StartDate = startDate;
-            Stopwatch = stopwatch;
+            StartDate = DateTime.Now;
+            Stopwatch = new Stopwatch();
         }
     }
 }

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -427,7 +427,7 @@ namespace PlayState
             {
                 elapsedSeconds = Convert.ToUInt64(suspendedTime.Value.TotalSeconds);
             }
-            return Convert.ToUInt64(DateTime.Now.Subtract(playStateData.FirstOrDefault(x => x.Game.Id == currentGame.Id).StartDate).TotalSeconds) - elapsedSeconds;
+            return Convert.ToUInt64(DateTime.Now.Subtract(playStateData.First(x => x.Game.Id == currentGame.Id).StartDate).TotalSeconds) - elapsedSeconds;
         }
 
         /// <summary>

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -779,7 +779,7 @@ namespace PlayState
             }
             else
             {
-                playStateData.Add(new PlayStateData(game, DateTime.Now, new Stopwatch()));
+                playStateData.Add(new PlayStateData(game));
                 logger.Debug($"Data for game {game.Name} with id {game.Id} was created");
             }
         }

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -45,7 +45,6 @@ namespace PlayState
         private HwndSource source = null;
         private bool globalHotkeyRegistered = false;
         private bool processesSuspended = false;
-        private bool showWindowsNotificationsStyle = false;
         private List<PlayStateData> playStateData;
 
         private PlayStateSettingsViewModel settings { get; set; }
@@ -486,11 +485,7 @@ namespace PlayState
         /// </summary>
         private void ShowNotification(NotificationTypes status)
         {
-            showWindowsNotificationsStyle = false;
-            if (settings.Settings.GlobalShowWindowsNotificationsStyle)
-            {
-                showWindowsNotificationsStyle = true;
-            }
+            var showWindowsNotificationsStyle = settings.Settings.GlobalShowWindowsNotificationsStyle;
 
             switch (status)
             {

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -269,12 +269,6 @@ namespace PlayState
 
             playedDateTime = DateTime.Now;
 
-            showWindowsNotificationsStyle = false;
-            if (settings.Settings.GlobalShowWindowsNotificationsStyle)
-            {
-                showWindowsNotificationsStyle = true;
-            }
-
             suspendPlaytimeOnly = false;
             if (settings.Settings.SubstractSuspendedPlaytimeOnStopped &&
                 (settings.Settings.GlobalOnlySuspendPlaytime ||
@@ -494,6 +488,12 @@ namespace PlayState
         /// </summary>
         private void ShowNotification(string status)
         {
+            showWindowsNotificationsStyle = false;
+            if (settings.Settings.GlobalShowWindowsNotificationsStyle)
+            {
+                showWindowsNotificationsStyle = true;
+            }
+
             switch (status)
             {
                 case "resumed": // for resuming process and playtime

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -439,8 +439,8 @@ namespace PlayState
         /// </summary>
         private string GetHoursString(ulong playtimeSeconds)
         {
-            TimeSpan playtime = TimeSpan.FromSeconds(playtimeSeconds);
-            int playtimeHours = playtime.Hours + playtime.Days * 24;
+            var playtime = TimeSpan.FromSeconds(playtimeSeconds);
+            var playtimeHours = playtime.Hours + playtime.Days * 24;
             if (playtimeHours == 1)
             {
                 if (playtime.Minutes == 1)

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -446,18 +446,19 @@ namespace PlayState
         private string GetHoursString(ulong playtimeSeconds)
         {
             TimeSpan playtime = TimeSpan.FromSeconds(playtimeSeconds);
-            if (playtime.Hours == 1)
+            int playtimeHours = playtime.Hours + playtime.Days * 24;
+            if (playtimeHours == 1)
             {
                 if (playtime.Minutes == 1)
                 {
-                    return String.Format(ResourceProvider.GetString("LOCPlayState_HourMinutePlayed"), playtime.Hours.ToString(), playtime.Minutes.ToString());
+                    return String.Format(ResourceProvider.GetString("LOCPlayState_HourMinutePlayed"), playtimeHours.ToString(), playtime.Minutes.ToString());
                 }
                 else
                 {
-                    return String.Format(ResourceProvider.GetString("LOCPlayState_HourMinutesPlayed"), playtime.Hours.ToString(), playtime.Minutes.ToString());
+                    return String.Format(ResourceProvider.GetString("LOCPlayState_HourMinutesPlayed"), playtimeHours.ToString(), playtime.Minutes.ToString());
                 }
             }
-            else if (playtime.Hours == 0 && playtime.Minutes == 0) // If the playtime is less than a minute, show the seconds instead
+            else if (playtimeHours == 0 && playtime.Minutes == 0) // If the playtime is less than a minute, show the seconds instead
             {
                 if (playtime.Seconds == 1)
                 {
@@ -472,11 +473,11 @@ namespace PlayState
             {
                 if (playtime.Minutes == 1)
                 {
-                    return String.Format(ResourceProvider.GetString("LOCPlayState_HoursMinutePlayed"), playtime.Hours.ToString(), playtime.Minutes.ToString());
+                    return String.Format(ResourceProvider.GetString("LOCPlayState_HoursMinutePlayed"), playtimeHours.ToString(), playtime.Minutes.ToString());
                 }
                 else
                 {
-                    return String.Format(ResourceProvider.GetString("LOCPlayState_HoursMinutesPlayed"), playtime.Hours.ToString(), playtime.Minutes.ToString());
+                    return String.Format(ResourceProvider.GetString("LOCPlayState_HoursMinutesPlayed"), playtimeHours.ToString(), playtime.Minutes.ToString());
                 }
             }
         }

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -510,7 +510,7 @@ namespace PlayState
                             .AddText(ResourceProvider.GetString("LOCPlayState_StatusResumedMessage"))
                             .AddText($"{ResourceProvider.GetString("LOCPlayState_Playtime")} {GetHoursString(GetRealPlaytime())}" +
                                 $"{Environment.NewLine}{ResourceProvider.GetString("LOCPlayState_TotalPlaytime")} {GetHoursString(GetRealPlaytime() + currentGame.Playtime)}")
-                            .AddHeroImage(new Uri(Path.Combine(PlayniteApi.Paths.ConfigurationPath, "library/files", currentGame.BackgroundImage))) // Show game image in the notification
+                            .AddHeroImage(new Uri(PlayniteApi.Database.GetFullFilePath(currentGame.BackgroundImage))) // Show game image in the notification
                             .Show();
                     }
                     break;
@@ -526,7 +526,7 @@ namespace PlayState
                             .AddText(ResourceProvider.GetString("LOCPlayState_StatusPlaytimeResumedMessage"))
                             .AddText($"{ResourceProvider.GetString("LOCPlayState_Playtime")} {GetHoursString(GetRealPlaytime())}" +
                                 $"{Environment.NewLine}{ResourceProvider.GetString("LOCPlayState_TotalPlaytime")} {GetHoursString(GetRealPlaytime() + currentGame.Playtime)}")
-                            .AddHeroImage(new Uri(Path.Combine(PlayniteApi.Paths.ConfigurationPath, "library/files", currentGame.BackgroundImage)))
+                            .AddHeroImage(new Uri(PlayniteApi.Database.GetFullFilePath(currentGame.BackgroundImage)))
                             .Show();
                     }
                     break;
@@ -542,7 +542,7 @@ namespace PlayState
                             .AddText(ResourceProvider.GetString("LOCPlayState_StatusSuspendedMessage"))
                             .AddText($"{ResourceProvider.GetString("LOCPlayState_Playtime")} {GetHoursString(GetRealPlaytime())}" +
                                 $"{Environment.NewLine}{ResourceProvider.GetString("LOCPlayState_TotalPlaytime")} {GetHoursString(GetRealPlaytime() + currentGame.Playtime)}")
-                            .AddHeroImage(new Uri(Path.Combine(PlayniteApi.Paths.ConfigurationPath, "library/files", currentGame.BackgroundImage)))
+                            .AddHeroImage(new Uri(PlayniteApi.Database.GetFullFilePath(currentGame.BackgroundImage)))
                             .Show();
                     }
                     break;
@@ -558,7 +558,7 @@ namespace PlayState
                             .AddText(ResourceProvider.GetString("LOCPlayState_StatusPlaytimeSuspendedMessage"))
                             .AddText($"{ResourceProvider.GetString("LOCPlayState_Playtime")} {GetHoursString(GetRealPlaytime())}" +
                                 $"{Environment.NewLine}{ResourceProvider.GetString("LOCPlayState_TotalPlaytime")} {GetHoursString(GetRealPlaytime() + currentGame.Playtime)}")
-                            .AddHeroImage(new Uri(Path.Combine(PlayniteApi.Paths.ConfigurationPath, "library/files", currentGame.BackgroundImage)))
+                            .AddHeroImage(new Uri(PlayniteApi.Database.GetFullFilePath(currentGame.BackgroundImage)))
                             .Show();
                     }
                     break;

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -270,8 +270,7 @@ namespace PlayState
             playedDateTime = DateTime.Now;
 
             showWindowsNotificationsStyle = false;
-            if (settings.Settings.GlobalShowWindowsNotificationsStyle ||
-                game.Features != null && game.Features.Any(a => a.Name.Equals("[PlayState] Show Windows notifications style", StringComparison.OrdinalIgnoreCase)))
+            if (settings.Settings.GlobalShowWindowsNotificationsStyle)
             {
                 showWindowsNotificationsStyle = true;
             }
@@ -850,24 +849,6 @@ namespace PlayState
                     Action = a => {
                         var featureRemovedCount = RemoveFeatureFromSelectedGames("[PlayState] Suspend Playtime only");
                         PlayniteApi.Dialogs.ShowMessage(string.Format(ResourceProvider.GetString("LOCPlayState_PlaytimeSuspendRemovedResultsMessage"), featureRemovedCount), "PlayState");
-                    }
-                },
-                new MainMenuItem
-                {
-                    Description = ResourceProvider.GetString("LOCPlayState_MenuItemAddToWindowsNotificationsStyleDescription"),
-                    MenuSection = "@PlayState",
-                    Action = a => {
-                        var featureAddedCount = AddFeatureToSelectedGames("[PlayState] Show Windows notifications style");
-                        PlayniteApi.Dialogs.ShowMessage(string.Format(ResourceProvider.GetString("LOCPlayState_WindowsNotificationsStyleAddedResultsMessage"), featureAddedCount), "PlayState");
-                    }
-                },
-                new MainMenuItem
-                {
-                    Description = ResourceProvider.GetString("LOCPlayState_MenuItemRemoveFromWindowsNotificationsStyleDescription"),
-                    MenuSection = "@PlayState",
-                    Action = a => {
-                        var featureRemovedCount = RemoveFeatureFromSelectedGames("[PlayState] Show Windows notifications style");
-                        PlayniteApi.Dialogs.ShowMessage(string.Format(ResourceProvider.GetString("LOCPlayState_WindowsNotificationsStyleRemovedResultsMessage"), featureRemovedCount), "PlayState");
                     }
                 }
             };

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -2,6 +2,7 @@
 using Playnite.SDK.Events;
 using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
+using PlayState.Enums;
 using PlayState.Models;
 using PlayState.ViewModels;
 using PlayState.Views;
@@ -157,7 +158,7 @@ namespace PlayState
                         }
                         else if (vkey == (uint)KeyInterop.VirtualKeyFromKey(settings.Settings.SavedInformationHotkeyGesture.Key))
                         {
-                            ShowNotification("information");
+                            ShowNotification(NotificationTypes.Information);
                         }
                         handled = true;
                         break;
@@ -486,7 +487,7 @@ namespace PlayState
         /// - "information" for showing the actual status<br/>
         /// </param>
         /// </summary>
-        private void ShowNotification(string status)
+        private void ShowNotification(NotificationTypes status)
         {
             showWindowsNotificationsStyle = false;
             if (settings.Settings.GlobalShowWindowsNotificationsStyle)
@@ -496,7 +497,7 @@ namespace PlayState
 
             switch (status)
             {
-                case "resumed": // for resuming process and playtime
+                case NotificationTypes.Resumed: // for resuming process and playtime
                     if (!showWindowsNotificationsStyle)
                     {
                         ShowSplashWindow(ResourceProvider.GetString("LOCPlayState_StatusResumedMessage"));
@@ -513,7 +514,7 @@ namespace PlayState
                             .Show();
                     }
                     break;
-                case "playtimeResumed": // for resuming playtime
+                case NotificationTypes.PlaytimeResumed: // for resuming playtime
                     if (!showWindowsNotificationsStyle)
                     {
                         ShowSplashWindow(ResourceProvider.GetString("LOCPlayState_StatusPlaytimeResumedMessage"));
@@ -529,7 +530,7 @@ namespace PlayState
                             .Show();
                     }
                     break;
-                case "suspended": // for suspend process and playtime
+                case NotificationTypes.Suspended: // for suspend process and playtime
                     if (!showWindowsNotificationsStyle)
                     {
                         ShowSplashWindow(ResourceProvider.GetString("LOCPlayState_StatusSuspendedMessage"));
@@ -545,7 +546,7 @@ namespace PlayState
                             .Show();
                     }
                     break;
-                case "playtimeSuspended": // for suspend playtime
+                case NotificationTypes.PlaytimeSuspended: // for suspend playtime
                     if (!showWindowsNotificationsStyle)
                     {
                         ShowSplashWindow(ResourceProvider.GetString("LOCPlayState_StatusPlaytimeSuspendedMessage"));
@@ -561,7 +562,7 @@ namespace PlayState
                             .Show();
                     }
                     break;
-                case "information": // for showing the actual status
+                case NotificationTypes.Information: // for showing the actual status
                     {
                         if (currentGame == null)
                         {
@@ -571,22 +572,22 @@ namespace PlayState
                         {
                             if (processesSuspended)
                             {
-                                ShowNotification("suspended");
+                                ShowNotification(NotificationTypes.Suspended);
                             }
                             else
                             {
-                                ShowNotification("playtimeSuspended");
+                                ShowNotification(NotificationTypes.PlaytimeSuspended);
                             }
                         }
                         else
                         {
                             if (processesSuspended)
                             {
-                                ShowNotification("resumed");
+                                ShowNotification(NotificationTypes.Resumed);
                             }
                             else
                             {
-                                ShowNotification("playtimeResumed");
+                                ShowNotification(NotificationTypes.PlaytimeResumed);
                             }
                         }
                     }
@@ -631,11 +632,11 @@ namespace PlayState
                         isSuspended = false;
                         if (processesSuspended)
                         {
-                            ShowNotification("resumed");
+                            ShowNotification(NotificationTypes.Resumed);
                         }
                         else
                         {
-                            ShowNotification("playtimeResumed");
+                            ShowNotification(NotificationTypes.PlaytimeResumed);
                         }
                         stopwatchList.FirstOrDefault(x => x.Item1 == currentGame.Id)?.Item2.Stop();
                         logger.Debug($"Game {currentGame.Name} resumed");
@@ -645,11 +646,11 @@ namespace PlayState
                         isSuspended = true;
                         if (processesSuspended)
                         {
-                            ShowNotification("suspended");
+                            ShowNotification(NotificationTypes.Suspended);
                         }
                         else
                         {
-                            ShowNotification("playtimeSuspended");
+                            ShowNotification(NotificationTypes.PlaytimeSuspended);
                         }
                         stopwatchList.FirstOrDefault(x => x.Item1 == currentGame.Id)?.Item2.Start();
                         logger.Debug($"Game {currentGame.Name} suspended");

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -778,7 +778,7 @@ namespace PlayState
 
         private void AddGame(Game game)
         {
-            if (playStateData.Any(x => x.Game.Id == game.Id && x.Stopwatch != null))
+            if (playStateData.Any(x => x.Game.Id == game.Id))
             {
                 logger.Debug($"Data for game {game.Name} with id {game.Id} already exists");
             }
@@ -794,7 +794,7 @@ namespace PlayState
             if (playStateData.Any(x => x.Game.Id == game.Id))
             {
                 playStateData.Remove(playStateData.Find(x => x.Game.Id == game.Id));
-                logger.Debug($"Stopwatch for game {game.Name} with id {game.Id} was removed on game stopped");
+                logger.Debug($"Data for game {game.Name} with id {game.Id} was removed on game stopped");
                 if (currentGame == game)
                 {
                     currentGame = playStateData.Any() ? playStateData.Last().Game : null;

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -791,9 +791,10 @@ namespace PlayState
 
         private void RemoveGame(Game game)
         {
-            if (playStateData.Any(x => x.Game.Id == game.Id))
+            var gameData = playStateData.FirstOrDefault(x => x.Game.Id == game.Id);
+            if (gameData != null)
             {
-                playStateData.Remove(playStateData.Find(x => x.Game.Id == game.Id));
+                playStateData.Remove(gameData);
                 logger.Debug($"Data for game {game.Name} with id {game.Id} was removed on game stopped");
                 if (currentGame == game)
                 {

--- a/source/Generic/PlayState/PlayState.csproj
+++ b/source/Generic/PlayState/PlayState.csproj
@@ -70,7 +70,6 @@
     <None Include="extension.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="app.xaml">
@@ -94,6 +93,17 @@
     <None Include="icon.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
+      <Version>7.1.2</Version>
+    </PackageReference>
+    <PackageReference Include="PlayniteSDK">
+      <Version>6.2.2</Version>
+    </PackageReference>
+    <PackageReference Include="System.Management">
+      <Version>5.0.0</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/source/Generic/PlayState/PlayState.csproj
+++ b/source/Generic/PlayState/PlayState.csproj
@@ -31,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Playnite.SDK, Version=6.2.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\PlayniteSDK.6.2.2\lib\net462\Playnite.SDK.dll</HintPath>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -65,6 +68,7 @@
     <None Include="extension.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="app.xaml">
@@ -88,17 +92,6 @@
     <None Include="icon.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
-      <Version>7.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="PlayniteSDK">
-      <Version>6.2.2</Version>
-    </PackageReference>
-    <PackageReference Include="System.Management">
-      <Version>5.0.0</Version>
-    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/source/Generic/PlayState/PlayState.csproj
+++ b/source/Generic/PlayState/PlayState.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,9 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Playnite.SDK, Version=6.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\PlayniteSDK.6.2.2\lib\net462\Playnite.SDK.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -68,7 +67,6 @@
     <None Include="extension.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="app.xaml">
@@ -92,6 +90,17 @@
     <None Include="icon.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
+      <Version>7.1.2</Version>
+    </PackageReference>
+    <PackageReference Include="PlayniteSDK">
+      <Version>6.2.2</Version>
+    </PackageReference>
+    <PackageReference Include="System.Management">
+      <Version>5.0.0</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/source/Generic/PlayState/PlayState.csproj
+++ b/source/Generic/PlayState/PlayState.csproj
@@ -50,6 +50,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Enums\NotificationTypes.cs" />
     <Compile Include="HotkeyHelper.cs" />
     <Compile Include="Models\Hotkey.cs" />
     <Compile Include="Models\ProcessItem.cs" />

--- a/source/Generic/PlayState/PlayState.csproj
+++ b/source/Generic/PlayState/PlayState.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="Enums\NotificationTypes.cs" />
     <Compile Include="HotkeyHelper.cs" />
+    <Compile Include="Models\PlayStateData.cs" />
     <Compile Include="Models\Hotkey.cs" />
     <Compile Include="Models\ProcessItem.cs" />
     <Compile Include="PlayState.cs" />

--- a/source/Generic/PlayState/PlayState.csproj
+++ b/source/Generic/PlayState/PlayState.csproj
@@ -12,8 +12,6 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/source/Generic/PlayState/PlayStateSettings.cs
+++ b/source/Generic/PlayState/PlayStateSettings.cs
@@ -18,6 +18,11 @@ namespace PlayState
         public string HotkeyText { get => hotkeyText; set => SetValue(ref hotkeyText, value); }
         public Hotkey SavedHotkeyGesture { get; set; } = new Hotkey(Key.A, (ModifierKeys)5);
         [DontSerialize]
+        private string informationHotkeyText = string.Empty;
+        [DontSerialize]
+        public string InformationHotkeyText { get => informationHotkeyText; set => SetValue(ref informationHotkeyText, value); }
+        public Hotkey SavedInformationHotkeyGesture { get; set; } = new Hotkey(Key.I, (ModifierKeys)5);
+        [DontSerialize]
         private bool substractSuspendedPlaytimeOnStopped = false;
         public bool SubstractSuspendedPlaytimeOnStopped { get => substractSuspendedPlaytimeOnStopped; set => SetValue(ref substractSuspendedPlaytimeOnStopped, value); }
         [DontSerialize]
@@ -26,6 +31,9 @@ namespace PlayState
         [DontSerialize]
         private bool globalOnlySuspendPlaytime = false;
         public bool GlobalOnlySuspendPlaytime { get => globalOnlySuspendPlaytime; set => SetValue(ref globalOnlySuspendPlaytime, value); }
+        [DontSerialize]
+        private bool globalShowWindowsNotificationsStyle = false;
+        public bool GlobalShowWindowsNotificationsStyle { get => globalShowWindowsNotificationsStyle; set => SetValue(ref globalShowWindowsNotificationsStyle, value); }
     }
 
     public class PlayStateSettingsViewModel : ObservableObject, ISettings
@@ -56,12 +64,26 @@ namespace PlayState
             if (savedSettings != null)
             {
                 Settings = savedSettings;
+                bool modifiedSettings = false;
                 if (Settings.SavedHotkeyGesture.Modifiers == ModifierKeys.None)
                 {
                     // Due to a bug in previous version that allowed 
                     // to save gestures without modifiers, this
                     // should be done to restore the default ModifierKeys
                     Settings.SavedHotkeyGesture.Modifiers = (ModifierKeys)5;
+                    modifiedSettings = true;
+                    
+                }
+                if (Settings.SavedInformationHotkeyGesture.Modifiers == ModifierKeys.None)
+                {
+                    // Due to a bug in previous version that allowed 
+                    // to save gestures without modifiers, this
+                    // should be done to restore the default ModifierKeys
+                    Settings.SavedInformationHotkeyGesture.Modifiers = (ModifierKeys)5;
+                    modifiedSettings = true;
+                }
+                if (modifiedSettings)
+                {
                     plugin.SavePluginSettings(Settings);
                 }
             }
@@ -77,6 +99,7 @@ namespace PlayState
             // Code executed when settings view is opened and user starts editing values.
             editingClone = Serialization.GetClone(Settings);
             Settings.HotkeyText = $"{Settings.SavedHotkeyGesture.Modifiers} + {Settings.SavedHotkeyGesture.Key}";
+            Settings.InformationHotkeyText = $"{Settings.SavedInformationHotkeyGesture.Modifiers} + {Settings.SavedInformationHotkeyGesture.Key}";
         }
 
         public void CancelEdit()

--- a/source/Generic/PlayState/PlayStateSettings.cs
+++ b/source/Generic/PlayState/PlayStateSettings.cs
@@ -64,26 +64,12 @@ namespace PlayState
             if (savedSettings != null)
             {
                 Settings = savedSettings;
-                bool modifiedSettings = false;
                 if (Settings.SavedHotkeyGesture.Modifiers == ModifierKeys.None)
                 {
                     // Due to a bug in previous version that allowed 
                     // to save gestures without modifiers, this
                     // should be done to restore the default ModifierKeys
                     Settings.SavedHotkeyGesture.Modifiers = (ModifierKeys)5;
-                    modifiedSettings = true;
-                    
-                }
-                if (Settings.SavedInformationHotkeyGesture.Modifiers == ModifierKeys.None)
-                {
-                    // Due to a bug in previous version that allowed 
-                    // to save gestures without modifiers, this
-                    // should be done to restore the default ModifierKeys
-                    Settings.SavedInformationHotkeyGesture.Modifiers = (ModifierKeys)5;
-                    modifiedSettings = true;
-                }
-                if (modifiedSettings)
-                {
                     plugin.SavePluginSettings(Settings);
                 }
             }

--- a/source/Generic/PlayState/PlayStateSettingsView.xaml
+++ b/source/Generic/PlayState/PlayStateSettingsView.xaml
@@ -52,7 +52,7 @@
                       ToolTip="{DynamicResource LOCPlayState_SettingGlobalOnlySuspendPlaytimeTooltip}"
                       IsChecked="{Binding Settings.GlobalOnlySuspendPlaytime}" Margin="0,0,0,10"/>
         </StackPanel>
-        <CheckBox Content="{DynamicResource LOCPlayState_SettingGlobalShowWindowsNotificationsStyleLabel}"
+        <CheckBox x:Name="ShowWindowsNotifications" Content="{DynamicResource LOCPlayState_SettingGlobalShowWindowsNotificationsStyleLabel}"
                   IsChecked="{Binding Settings.GlobalShowWindowsNotificationsStyle}"
                   ToolTip="{DynamicResource LOCPlayState_SettingGlobalShowWindowsNotificationsStyleTooltip}"
                   Margin="0,0,0,10"/>

--- a/source/Generic/PlayState/PlayStateSettingsView.xaml
+++ b/source/Generic/PlayState/PlayStateSettingsView.xaml
@@ -23,6 +23,23 @@
                     Content="{DynamicResource LOCPlayState_SettingChangeHotkeyButtonLabel}"
                     Click="SetHotkeyButton_Click"/>
         </DockPanel>
+        <DockPanel LastChildFill="False">
+            <TextBlock Text="{DynamicResource LOCPlayState_SettingConfiguredInformationHotkeyLabel}"
+                       DockPanel.Dock="Left"
+                       VerticalAlignment="Center"/>
+            <TextBox x:Name="TbInformationHotkey"
+                     Text="{Binding Settings.InformationHotkeyText}"
+                     DockPanel.Dock="Left"
+                     IsReadOnly="True" MinWidth="200"
+                     VerticalAlignment="Center"
+                     Margin="10,0,0,0" Focusable="False" />
+            <Button x:Name="SetInformationHotkeyButton"
+                    DockPanel.Dock="Left"
+                    Margin="10,0,0,0"
+                    VerticalAlignment="Center"
+                    Content="{DynamicResource LOCPlayState_SettingChangeHotkeyButtonLabel}"
+                    Click="SetInformationHotkeyButton_Click"/>
+        </DockPanel>
         <TextBlock Text="{DynamicResource LOCPlayState_SettingNotes}" Margin="0,10,0,20" TextWrapping="Wrap"/>
         <CheckBox x:Name="CbSubstractOnSuspended" Content="{DynamicResource LOCPlayState_SettingSubstractSuspendedPlaytimeOnStoppedLabel}"
                   IsChecked="{Binding Settings.SubstractSuspendedPlaytimeOnStopped}"
@@ -35,5 +52,9 @@
                       ToolTip="{DynamicResource LOCPlayState_SettingGlobalOnlySuspendPlaytimeTooltip}"
                       IsChecked="{Binding Settings.GlobalOnlySuspendPlaytime}" Margin="0,0,0,10"/>
         </StackPanel>
+        <CheckBox Content="{DynamicResource LOCPlayState_SettingGlobalShowWindowsNotificationsStyleLabel}"
+                  IsChecked="{Binding Settings.GlobalShowWindowsNotificationsStyle}"
+                  ToolTip="{DynamicResource LOCPlayState_SettingGlobalShowWindowsNotificationsStyleTooltip}"
+                  Margin="0,0,0,10"/>
     </StackPanel>
 </UserControl>

--- a/source/Generic/PlayState/PlayStateSettingsView.xaml.cs
+++ b/source/Generic/PlayState/PlayStateSettingsView.xaml.cs
@@ -24,6 +24,7 @@ namespace PlayState
         {
             InitializeComponent();
             TbHotkey.PreviewKeyDown += HotkeyTextBox_PreviewKeyDown;
+            TbInformationHotkey.PreviewKeyDown += InformationHotkeyTextBox_PreviewKeyDown;
         }
 
         private void HotkeyTextBox_PreviewKeyDown(object sender, KeyEventArgs e)
@@ -85,6 +86,67 @@ namespace PlayState
             tbHotkey.Focusable = false;
             setHotkeyButton.Focus();
             setHotkeyButton.Content = ResourceProvider.GetString("LOCPlayState_SettingChangeHotkeyButtonLabel");
+        }
+
+        private void InformationHotkeyTextBox_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (DataContext is PlayStateSettingsViewModel settings)
+            {
+                e.Handled = true;
+                SetInformationHotkey(e, TbInformationHotkey, SetInformationHotkeyButton, settings.Settings.SavedInformationHotkeyGesture);
+            }
+        }
+
+        private void SetInformationHotkeyButton_Click(object sender, RoutedEventArgs e)
+        {
+            TbInformationHotkey.Focusable = true;
+            TbInformationHotkey.Focus();
+            SetInformationHotkeyButton.Content = ResourceProvider.GetString("LOCPlayState_SettingPressHotkeyPromtButtonLabel");
+        }
+
+        private void SetInformationHotkey(KeyEventArgs e, TextBox tbInformationHotkey, Button setInformationHotkeyButton, Hotkey informationHotkeyGesture)
+        {
+            // Get modifiers and key data
+            var modifiers = Keyboard.Modifiers;
+            var key = e.Key;
+
+            // When Alt is pressed, SystemKey is used instead
+            if (key == Key.System)
+            {
+                key = e.SystemKey;
+            }
+
+            // Pressing delete, backspace or escape without modifiers clears the current value
+            if (modifiers == ModifierKeys.None ||
+                (key == Key.Delete || key == Key.Back || key == Key.Escape))
+            {
+                // Hotkey = null;
+                return;
+            }
+
+            // If no actual key was pressed - return
+            if (key == Key.LeftCtrl ||
+                key == Key.RightCtrl ||
+                key == Key.LeftAlt ||
+                key == Key.RightAlt ||
+                key == Key.LeftShift ||
+                key == Key.RightShift ||
+                key == Key.LWin ||
+                key == Key.RWin ||
+                key == Key.Clear ||
+                key == Key.OemClear ||
+                key == Key.Apps)
+            {
+                return;
+            }
+
+            tbInformationHotkey.Text = $"{modifiers} + {key}";
+
+            informationHotkeyGesture.Key = key;
+            informationHotkeyGesture.Modifiers = modifiers;
+            tbInformationHotkey.Focusable = false;
+            setInformationHotkeyButton.Focus();
+            setInformationHotkeyButton.Content = ResourceProvider.GetString("LOCPlayState_SettingChangeHotkeyButtonLabel");
         }
 
     }

--- a/source/Generic/PlayState/PlayStateSettingsView.xaml.cs
+++ b/source/Generic/PlayState/PlayStateSettingsView.xaml.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -25,6 +26,10 @@ namespace PlayState
             InitializeComponent();
             TbHotkey.PreviewKeyDown += HotkeyTextBox_PreviewKeyDown;
             TbInformationHotkey.PreviewKeyDown += InformationHotkeyTextBox_PreviewKeyDown;
+            if (!IsWindows10Or11())
+            {
+                ShowWindowsNotifications.IsEnabled = false;
+            }
         }
 
         private void HotkeyTextBox_PreviewKeyDown(object sender, KeyEventArgs e)
@@ -147,6 +152,12 @@ namespace PlayState
             tbInformationHotkey.Focusable = false;
             setInformationHotkeyButton.Focus();
             setInformationHotkeyButton.Content = ResourceProvider.GetString("LOCPlayState_SettingChangeHotkeyButtonLabel");
+        }
+
+        private bool IsWindows10Or11()
+        {
+            var productName = (string) Microsoft.Win32.Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion")?.GetValue("productName");
+            return productName.Contains("Windows 10") || productName.Contains("Windows 11");
         }
 
     }

--- a/source/Generic/PlayState/packages.config
+++ b/source/Generic/PlayState/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="PlayniteSDK" version="6.2.2" targetFramework="net462" />
   <package id="System.Management" version="5.0.0" targetFramework="net462" />
+  <package id="Microsoft.Toolkit.Uwp.Notifications" version="7.1.2" targetFramework="net462" />
 </packages>

--- a/source/Generic/PlayState/packages.config
+++ b/source/Generic/PlayState/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="PlayniteSDK" version="6.2.2" targetFramework="net462" />
-  <package id="System.Management" version="5.0.0" targetFramework="net462" />
-</packages>

--- a/source/Generic/PlayState/packages.config
+++ b/source/Generic/PlayState/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="PlayniteSDK" version="6.2.2" targetFramework="net462" />
+  <package id="System.Management" version="5.0.0" targetFramework="net462" />
+</packages>

--- a/source/Generic/PlayState/packages.config
+++ b/source/Generic/PlayState/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="PlayniteSDK" version="6.2.2" targetFramework="net462" />
-  <package id="System.Management" version="5.0.0" targetFramework="net462" />
-  <package id="Microsoft.Toolkit.Uwp.Notifications" version="7.1.2" targetFramework="net462" />
-</packages>


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.

Changes:
- Added a setting for set a hotkey to show information about the current session of the game.
- Added a setting for use Windows notifications instead Playnite overlay system.
- Show information about play time on the notifications when Windows notifications are enabled.

As stated on the new settings note, in order to Windows notifications be showed it requires that Playnite is added to the priority list if the Focuss Assist is enabled when playing a game.

The notifications will be still showed after finishing the game since currentGame doesn't get deleted after finishing the game. I don't see any reason to not remove it on OnGameStopped event. Could you confirm that this is the case so I'll delete currentGame variable when finishing the game in order to avoid notifications about an ended game?