### PR TITLE
Pass "Start" or "Stop" to SK service exe

### DIFF
--- a/source/Generic/SpecialKHelper/SpecialKHelper.cs
+++ b/source/Generic/SpecialKHelper/SpecialKHelper.cs
@@ -509,14 +509,15 @@ namespace SpecialKHelper
             var info = new ProcessStartInfo(servletExe)
             {
                 WorkingDirectory = Path.GetDirectoryName(servletExe),
-                UseShellExecute = true
+                UseShellExecute = true,
+                Arguments = "Start",
             };
             Process.Start(info);
 
             var i = 0;
             while (i < 12)
             {
-                Thread.Sleep(40);
+                Thread.Sleep(100);
                 if (File.Exists(servletPid))
                 {
                     logger.Info($"Special K global service for \"{cpuArchitecture}\" started. Pid file detected in {servletPid}");
@@ -560,7 +561,8 @@ namespace SpecialKHelper
             var info = new ProcessStartInfo(servletExe)
             {
                 WorkingDirectory = Path.GetDirectoryName(servletExe),
-                UseShellExecute = true
+                UseShellExecute = true,
+                Arguments = "Stop",
             };
             Process.Start(info);
 


### PR DESCRIPTION
SKIF passes these parameters to the service too:
https://github.com/SpecialKO/SKIF/blob/c53a5c7b37fb22a4c01145753f1167681b1e6e3f/src/injection.cpp#L175

This seems to fix an issue where it fails to launch the services after
the first time

I think this fixes the issue I was seeing. I managed to break SKIF itself by double clicking `SKIFsvc64.exe` twice. It seems it's not supposed to be run with no arguments.