### PR TITLE
Improved processes handling

### DIFF
--- a/source/Generic/PlayState/Models/PlayStateData.cs
+++ b/source/Generic/PlayState/Models/PlayStateData.cs
@@ -13,12 +13,18 @@ namespace PlayState.Models
         public Game Game { get; set; }
         public DateTime StartDate { get; set; }
         public Stopwatch Stopwatch { get; set; }
+        public List<ProcessItem> GameProcesses { get; set; }
+        public bool IsSuspended { get; set; }
+        public bool ProcessesSuspended { get; set; }
 
-        public PlayStateData(Game game)
+        public PlayStateData(Game game, List<ProcessItem> gameProcesses)
         {
             Game = game;
             StartDate = DateTime.Now;
             Stopwatch = new Stopwatch();
+            GameProcesses = gameProcesses;
+            IsSuspended = false;
+            ProcessesSuspended = false;
         }
     }
 }

--- a/source/Generic/PlayState/Models/ProcessItem.cs
+++ b/source/Generic/PlayState/Models/ProcessItem.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace PlayState.Models
 {
-    class ProcessItem
+    public class ProcessItem
     {
         public string ExecutablePath;
         public Process Process;

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -545,7 +545,7 @@ namespace PlayState
             {
                 return;
             }
-            
+
             var sb = new StringBuilder();
             switch (status)
             {

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -35,17 +35,14 @@ namespace PlayState
         private Game currentGame;
         private List<string> exclusionList;
         private string gameInstallDir;
-        private bool isSuspended = false;
         private Window currentSplashWindow;
         private DispatcherTimer timer;
-        private List<ProcessItem> gameProcesses;
         private bool suspendPlaytimeOnly = false;
         private Window mainWindow;
         private WindowInteropHelper windowInterop;
         private IntPtr mainWindowHandle;
         private HwndSource source = null;
         private bool globalHotkeyRegistered = false;
-        private bool processesSuspended = false;
         private List<PlayStateData> playStateData;
 
         private PlayStateSettingsViewModel settings { get; set; }
@@ -189,11 +186,11 @@ namespace PlayState
                         uint vkey = ((uint)lParam >> 16) & 0xFFFF;
                         if (vkey == (uint)KeyInterop.VirtualKeyFromKey(settings.Settings.SavedHotkeyGesture.Key))
                         {
-                            SwitchGameState();
+                            SwitchGameState(currentGame);
                         }
                         else if (vkey == (uint)KeyInterop.VirtualKeyFromKey(settings.Settings.SavedInformationHotkeyGesture.Key))
                         {
-                            ShowNotification(NotificationTypes.Information);
+                            ShowNotification(NotificationTypes.Information, currentGame);
                         }
                         handled = true;
                         break;
@@ -291,9 +288,9 @@ namespace PlayState
         {
             InitializePlaytimeInfoFile(); // Temporary workaround for sharing PlayState paused time until Playnite allows to share data among extensions
 
-            if (isSuspended)
+            if (currentGame != null && GetGameData(currentGame).IsSuspended)
             {
-                SwitchGameState();
+                SwitchGameState(currentGame);
             }
 
             var game = args.Game;
@@ -303,6 +300,8 @@ namespace PlayState
                 return;
             }
 
+            List<ProcessItem> gameProcesses;
+
             suspendPlaytimeOnly = false;
             if (settings.Settings.SubstractSuspendedPlaytimeOnStopped &&
                 (settings.Settings.GlobalOnlySuspendPlaytime ||
@@ -311,7 +310,7 @@ namespace PlayState
                 suspendPlaytimeOnly = true;
                 currentGame = game;
                 gameProcesses = null;
-                AddGame(game);
+                AddGame(game, gameProcesses);
                 return;
             }
 
@@ -319,7 +318,6 @@ namespace PlayState
             {
                 currentGame = game;
                 gameProcesses = null;
-                isSuspended = false;
                 logger.Debug($"Changed game to {currentGame.Name} game processes");
                 var sourceAction = args.SourceAction;
                 if (sourceAction?.Type == GameActionType.Emulator)
@@ -339,7 +337,7 @@ namespace PlayState
                         gameProcesses = GetProcessesWmiQuery(false, profile.Executable.ToLower());
                         if (gameProcesses.Count > 0)
                         {
-                            AddGame(game);
+                            AddGame(game, gameProcesses);
                         }
                     }
                     return;
@@ -362,7 +360,7 @@ namespace PlayState
                 if (gameProcesses.Count > 0)
                 {
                     logger.Debug($"Found {gameProcesses.Count} game processes");
-                    AddGame(game);
+                    AddGame(game, gameProcesses);
                     return;
                 }
 
@@ -390,7 +388,7 @@ namespace PlayState
                     if (gameProcesses.Count > 0)
                     {
                         logger.Debug($"Found {gameProcesses.Count} game processes");
-                        AddGame(game);
+                        AddGame(game, gameProcesses);
                         return;
                     }
                     else
@@ -411,6 +409,21 @@ namespace PlayState
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Method for obtaining the gameData of the asked game.
+        /// </summary>
+        private PlayStateData GetGameData(Game game)
+        {
+            if (game == null || !playStateData.Any(x => x.Game.Id == game.Id))
+            {
+                return null;
+            }
+            else
+            {
+                return playStateData.Find(x => x.Game.Id == game.Id);
+            }
         }
 
         private void CreateSplashWindow()
@@ -455,15 +468,21 @@ namespace PlayState
         /// <summary>
         /// Method for obtaining the real playtime of the actual session, which is the playtime after substracting the paused time.
         /// </summary>
-        private ulong GetRealPlaytime()
+        private ulong GetRealPlaytime(Game game)
         {
-            var suspendedTime = playStateData.FirstOrDefault(x => x.Game.Id == currentGame.Id)?.Stopwatch.Elapsed;
+            var gameData = GetGameData(game);
+            if (gameData == null)
+            {
+                return 0;
+            }
+            
+            var suspendedTime = gameData.Stopwatch.Elapsed;
             ulong elapsedSeconds = 0;
             if (suspendedTime != null)
             {
-                elapsedSeconds = Convert.ToUInt64(suspendedTime.Value.TotalSeconds);
+                elapsedSeconds = Convert.ToUInt64(suspendedTime.TotalSeconds);
             }
-            return Convert.ToUInt64(DateTime.Now.Subtract(playStateData.First(x => x.Game.Id == currentGame.Id).StartDate).TotalSeconds) - elapsedSeconds;
+            return Convert.ToUInt64(DateTime.Now.Subtract(gameData.StartDate).TotalSeconds) - elapsedSeconds;
         }
 
         /// <summary>
@@ -519,13 +538,14 @@ namespace PlayState
         /// - "information" for showing the actual status<br/>
         /// </param>
         /// </summary>
-        private void ShowNotification(NotificationTypes status)
+        private void ShowNotification(NotificationTypes status, Game game)
         {
-            if (currentGame == null || !playStateData.Any(x => x.Game.Id == currentGame.Id))
+            var gameData = GetGameData(game);
+            if (gameData == null)
             {
                 return;
             }
-
+            
             var sb = new StringBuilder();
             switch (status)
             {
@@ -547,9 +567,9 @@ namespace PlayState
                     break;
                 case NotificationTypes.Information:
                     sb.Append($"{ResourceProvider.GetString("LOCPlayState_StatusInformationMessage")} ");
-                    if (isSuspended)
+                    if (gameData.IsSuspended)
                     {
-                        if (processesSuspended)
+                        if (gameData.ProcessesSuspended)
                         {
                             sb.Append(ResourceProvider.GetString("LOCPlayState_StatusSuspendedMessage"));
                         }
@@ -560,7 +580,7 @@ namespace PlayState
                     }
                     else
                     {
-                        if (processesSuspended)
+                        if (gameData.ProcessesSuspended)
                         {
                             sb.Append(ResourceProvider.GetString("LOCPlayState_StatusResumedMessage"));
                         }
@@ -576,52 +596,48 @@ namespace PlayState
 
             if (settings.Settings.NotificationShowSessionPlaytime)
             {
-                sb.Append($"\n{ResourceProvider.GetString("LOCPlayState_Playtime")} {GetHoursString(GetRealPlaytime())}");
+                sb.Append($"\n{ResourceProvider.GetString("LOCPlayState_Playtime")} {GetHoursString(GetRealPlaytime(game))}");
             }
             if (settings.Settings.NotificationShowTotalPlaytime)
             {
-                sb.Append($"\n{ResourceProvider.GetString("LOCPlayState_TotalPlaytime")} {GetHoursString(GetRealPlaytime() + currentGame.Playtime)}");
+                sb.Append($"\n{ResourceProvider.GetString("LOCPlayState_TotalPlaytime")} {GetHoursString(GetRealPlaytime(game) + game.Playtime)}");
             }
             var notificationMessage = sb.ToString();
 
             if (settings.Settings.GlobalShowWindowsNotificationsStyle && isWindows10Or11)
             {
                 new ToastContentBuilder()
-                    .AddText(currentGame.Name) // First AddText field will act as a title
+                    .AddText(game.Name) // First AddText field will act as a title
                     .AddText(notificationMessage)
-                    .AddHeroImage(new Uri(PlayniteApi.Database.GetFullFilePath(currentGame.BackgroundImage))) // Show game image in the notification
+                    .AddHeroImage(new Uri(PlayniteApi.Database.GetFullFilePath(game.BackgroundImage))) // Show game image in the notification
                     .Show();
             }
             else
             {
-                ShowSplashWindow(currentGame.Name, notificationMessage);
+                ShowSplashWindow(game.Name, notificationMessage);
             }
         }
 
-        private void SwitchGameState()
+        private void SwitchGameState(Game game)
         {
-            if (currentGame == null)
+            var gameData = GetGameData(game);
+            if (gameData == null)
             {
-                if (isSuspended)
-                {
-                    isSuspended = false;
-                    processesSuspended = false;
-                }
                 return;
             }
 
             try
             {
-                processesSuspended = false;
-                if (gameProcesses != null && gameProcesses.Count > 0)
+                gameData.ProcessesSuspended = false;
+                if (gameData.GameProcesses != null && gameData.GameProcesses.Count > 0)
                 {
-                    foreach (var gameProcess in gameProcesses)
+                    foreach (var gameProcess in gameData.GameProcesses)
                     {
                         if (gameProcess == null || gameProcess.Process.Handle == null || gameProcess.Process.Handle == IntPtr.Zero)
                         {
                             return;
                         }
-                        if (isSuspended)
+                        if (gameData.IsSuspended)
                         {
                             NtResumeProcess(gameProcess.Process.Handle);
                         }
@@ -630,46 +646,46 @@ namespace PlayState
                             NtSuspendProcess(gameProcess.Process.Handle);
                         }
                     }
-                    processesSuspended = true;
+                    gameData.ProcessesSuspended = true;
                 }
 
-                if (processesSuspended || suspendPlaytimeOnly)
+                if (gameData.ProcessesSuspended || suspendPlaytimeOnly)
                 {
-                    if (isSuspended)
+                    if (gameData.IsSuspended)
                     {
-                        isSuspended = false;
-                        if (processesSuspended)
+                        gameData.IsSuspended = false;
+                        if (gameData.ProcessesSuspended)
                         {
-                            ShowNotification(NotificationTypes.Resumed);
+                            ShowNotification(NotificationTypes.Resumed, game);
                         }
                         else
                         {
-                            ShowNotification(NotificationTypes.PlaytimeResumed);
+                            ShowNotification(NotificationTypes.PlaytimeResumed, game);
                         }
-                        playStateData.Find(x => x.Game.Id == currentGame.Id)?.Stopwatch.Stop();
-                        logger.Debug($"Game {currentGame.Name} resumed");
+                        gameData.Stopwatch.Stop();
+                        logger.Debug($"Game {game.Name} resumed");
                     }
                     else
                     {
-                        isSuspended = true;
-                        if (processesSuspended)
+                        gameData.IsSuspended = true;
+                        if (gameData.ProcessesSuspended)
                         {
-                            ShowNotification(NotificationTypes.Suspended);
+                            ShowNotification(NotificationTypes.Suspended, game);
                         }
                         else
                         {
-                            ShowNotification(NotificationTypes.PlaytimeSuspended);
+                            ShowNotification(NotificationTypes.PlaytimeSuspended, game);
                         }
-                        playStateData.Find(x => x.Game.Id == currentGame.Id)?.Stopwatch.Start();
-                        logger.Debug($"Game {currentGame.Name} suspended");
+                        gameData.Stopwatch.Start();
+                        logger.Debug($"Game {game.Name} suspended");
                     }
                 }
             }
             catch (Exception e)
             {
                 logger.Error(e, "Error while suspending or resuming game");
-                gameProcesses = null;
-                playStateData.Find(x => x.Game.Id == currentGame.Id)?.Stopwatch.Stop();
+                gameData.GameProcesses = null;
+                gameData.Stopwatch.Stop();
             }
         }
 
@@ -747,10 +763,12 @@ namespace PlayState
         public override void OnGameStopped(OnGameStoppedEventArgs args)
         {
             var game = args.Game;
-            if (currentGame != null && currentGame.Id == game.Id)
+            var gameData = GetGameData(game);
+            if (gameData != null)
             {
-                gameProcesses = null;
+                gameData.GameProcesses = null;
             }
+
             if (currentSplashWindow != null)
             {
                 currentSplashWindow.Hide();
@@ -762,10 +780,10 @@ namespace PlayState
                 if (game.PluginId == Guid.Empty ||
                     (game.PluginId != Guid.Empty && !settings.Settings.SubstractOnlyNonLibraryGames))
                 {
-                    var suspendedTime = playStateData.Find(x => x.Game.Id == currentGame.Id)?.Stopwatch.Elapsed;
+                    var suspendedTime = gameData.Stopwatch.Elapsed;
                     if (suspendedTime != null)
                     {
-                        var elapsedSeconds = Convert.ToUInt64(suspendedTime.Value.TotalSeconds);
+                        var elapsedSeconds = Convert.ToUInt64(suspendedTime.TotalSeconds);
                         logger.Debug($"Suspend elapsed seconds for game {game.Name} was {elapsedSeconds}");
                         ExportPausedTimeInfo(game, elapsedSeconds); // Temporary workaround for sharing PlayState paused time until Playnite allows to share data among extensions
                         if (elapsedSeconds != 0)
@@ -782,7 +800,7 @@ namespace PlayState
             RemoveGame(game);
         }
 
-        private void AddGame(Game game)
+        private void AddGame(Game game, List<ProcessItem> gameProcesses)
         {
             if (playStateData.Any(x => x.Game.Id == game.Id))
             {
@@ -790,14 +808,14 @@ namespace PlayState
             }
             else
             {
-                playStateData.Add(new PlayStateData(game));
+                playStateData.Add(new PlayStateData(game, gameProcesses));
                 logger.Debug($"Data for game {game.Name} with id {game.Id} was created");
             }
         }
 
         private void RemoveGame(Game game)
         {
-            var gameData = playStateData.FirstOrDefault(x => x.Game.Id == game.Id);
+            var gameData = GetGameData(game);
             if (gameData != null)
             {
                 playStateData.Remove(gameData);

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -416,14 +416,7 @@ namespace PlayState
         /// </summary>
         private PlayStateData GetGameData(Game game)
         {
-            if (game == null || !playStateData.Any(x => x.Game.Id == game.Id))
-            {
-                return null;
-            }
-            else
-            {
-                return playStateData.Find(x => x.Game.Id == game.Id);
-            }
+            return playStateData.FirstOrDefault(x => x.Game.Id == game.Id);
         }
 
         private void CreateSplashWindow()


### PR DESCRIPTION
- Added processes to PlayStateData, and their states (isSuspended, processesSuspended)
- When you have more than one game opened, now you will be able to pause/resume the currentGame always. So, if you open Game1, and after you open Game2, but after a while you close Game2, you will be able to fully control again Game1.
- Refactored code to allow in the future handle several games at the same time (show notifications for another game that is not the currentGame, pause/resume other game that is not the currentGame, etc).

I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.
