### PR TITLE
(PlayState) Added override suspend playtime / Set suspendPlaytimeOnly variable by game instead of globally

### DIFF
--- a/source/Generic/PlayState/Localization/en_US.xaml
+++ b/source/Generic/PlayState/Localization/en_US.xaml
@@ -2,17 +2,17 @@
     <sys:String x:Key="LOCPlayState_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCPlayState_MenuItemAddToBlacklistDescription">Add selected games to PlayState Blacklist</sys:String>
     <sys:String x:Key="LOCPlayState_MenuItemRemoveFromBlacklistDescription">Remove selected games from Playstate Blacklist</sys:String>
-    <sys:String x:Key="LOCPlayState_MenuItemAddToPlaytimeSuspendDescription">Configure selected games to force to only suspend playtime</sys:String>
-    <sys:String x:Key="LOCPlayState_MenuItemRemoveFromPlaytimeSuspendDescription">Remove configuration to force to only suspend playtime</sys:String>
+    <sys:String x:Key="LOCPlayState_MenuItemAddToPlaytimeSuspendDescription">Configure selected games to override suspend playtime only setting</sys:String>
+    <sys:String x:Key="LOCPlayState_MenuItemRemoveFromPlaytimeSuspendDescription">Remove configuration to override suspend playtime only setting</sys:String>
     <sys:String x:Key="LOCPlayState_NotificationMessageHotkeyRegisterFailed" xml:space="preserve">Failed to register configured Hotkey {0}
 
 You can try using a diferent HotKey combination to possibly fix the issue</sys:String>
     <sys:String x:Key="LOCPlayState_BlacklistAddedResultsMessage">Added {0} game(s) to the PlayState blacklist.</sys:String>
     <sys:String x:Key="LOCPlayState_BlacklistRemovedResultsMessage">Removed {0} game(s) from the PlayState blacklist.</sys:String>
-    <sys:String x:Key="LOCPlayState_PlaytimeSuspendAddedResultsMessage">Configured {0} game(s) to force to only suspend playtime when using the configured hotkey.</sys:String>
-    <sys:String x:Key="LOCPlayState_PlaytimeSuspendRemovedResultsMessage" xml:space="preserve">Removed configuration to force to only suspend playtime when using the configured hotkey from {0} game(s).
+    <sys:String x:Key="LOCPlayState_PlaytimeSuspendAddedResultsMessage">Configured {0} game(s) to override suspend playtime only setting when using the configured hotkey.</sys:String>
+    <sys:String x:Key="LOCPlayState_PlaytimeSuspendRemovedResultsMessage" xml:space="preserve">Removed configuration to override suspend playtime only setting when using the configured hotkey from {0} game(s).
 
-Games will be suspended when using the configured hotkey.</sys:String>
+Games will respect the state of the global setting of only suspend playtime count globally and not the game processes.</sys:String>
     <sys:String x:Key="LOCPlayState_StatusSuspendedMessage">Game suspended</sys:String>
     <sys:String x:Key="LOCPlayState_StatusResumedMessage">Game resumed</sys:String>
     <sys:String x:Key="LOCPlayState_StatusPlaytimeSuspendedMessage">Playtime suspended</sys:String>
@@ -31,6 +31,10 @@ Changing this setting requires restart.</sys:String>
     <sys:String x:Key="LOCPlayState_SettingsWinNotificationNote" xml:space="preserve">If you have Focus Assist enabled when playing a game and fullscreen mode, you have to add Playnite to priority list in order to receive Windows notifications and configure them to allow to display them.
 
 This feature is only supported on Windows 10 and Windows 11</sys:String>
+    <sys:String x:Key="LOCPlayState_MessageSuspPlaytimeOnlyMigration" xml:space="preserve">PlayState has modified the behaviour of the game feature previously called "[PlayState] Suspend Playtime only". This feature is now called "[PlayState] Override suspend playtime only setting".
+
+With this new game feature, the games that have it will override the state of "Only suspend playtime count globally and not the game processes" setting, and so will do the opposite of that setting.
+So if that setting is enabled and this feature is added, that game will suspend playtime and the game processes, and if that setting is disabled and this feature added, will only suspend playtime and not the game processes.</sys:String>
     <sys:String x:Key="LOCPlayState_MessageWinStyleNotificationsFirstSetup" xml:space="preserve">PlayState has added support to display notifications as native windows notifications. This is enabled by default and can be changed from the extension settings.
 
 For better compatibility with games, some adjustments to your Windows configuration is required. A link that contains the the instructions for this will be opened after closing this dialog.</sys:String>
@@ -41,7 +45,8 @@ For better compatibility with games, some adjustments to your Windows configurat
     <sys:String x:Key="LOCPlayState_SettingGlobalOnlySuspendPlaytimeLabel">Only suspend playtime count globally and not the game processes</sys:String>
     <sys:String x:Key="LOCPlayState_SettingGlobalOnlySuspendPlaytimeTooltip" xml:space="preserve">By enabling this option, all games won't be suspended when using the configured hotkey and only the time will be counted to substracted from the game playtime when it stops.
     
-This can also be applied individually per game by adding a feature named "[PlayState] Suspend playtime only" to a game</sys:String>
+The state of this setting can be overridden individually per game by adding a feature named "[PlayState] Override suspend playtime only setting" to a game.
+If this feature is added, the behaviour of the pause / resume of the game will be the opposite of the state of this setting.</sys:String>
     <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleLabel">Show native Windows notifications instead of Playnite notification window</sys:String>
     <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleTooltip">By enabling this option, games will show native Windows notifications instead of Playnite notification window.</sys:String>
     <sys:String x:Key="LOCPlayState_SettingNotificationShowSessionPlaytime">Display session playtime in notification message</sys:String>

--- a/source/Generic/PlayState/Localization/en_US.xaml
+++ b/source/Generic/PlayState/Localization/en_US.xaml
@@ -4,15 +4,17 @@
     <sys:String x:Key="LOCPlayState_MenuItemRemoveFromBlacklistDescription">Remove selected games from Playstate Blacklist</sys:String>
     <sys:String x:Key="LOCPlayState_MenuItemAddToPlaytimeSuspendDescription">Configure selected games to force to only suspend playtime</sys:String>
     <sys:String x:Key="LOCPlayState_MenuItemRemoveFromPlaytimeSuspendDescription">Remove configuration to force to only suspend playtime</sys:String>
+    <sys:String x:Key="LOCPlayState_MenuItemAddToProcessesSuspendDescription">Configure selected games to force to suspend processes</sys:String>
+    <sys:String x:Key="LOCPlayState_MenuItemRemoveFromProcessesSuspendDescription">Remove configuration to force to suspend processes</sys:String>
     <sys:String x:Key="LOCPlayState_NotificationMessageHotkeyRegisterFailed" xml:space="preserve">Failed to register configured Hotkey {0}
 
 You can try using a diferent HotKey combination to possibly fix the issue</sys:String>
     <sys:String x:Key="LOCPlayState_BlacklistAddedResultsMessage">Added {0} game(s) to the PlayState blacklist.</sys:String>
     <sys:String x:Key="LOCPlayState_BlacklistRemovedResultsMessage">Removed {0} game(s) from the PlayState blacklist.</sys:String>
     <sys:String x:Key="LOCPlayState_PlaytimeSuspendAddedResultsMessage">Configured {0} game(s) to force to only suspend playtime when using the configured hotkey.</sys:String>
-    <sys:String x:Key="LOCPlayState_PlaytimeSuspendRemovedResultsMessage" xml:space="preserve">Removed configuration to force to only suspend playtime when using the configured hotkey from {0} game(s).
-
-Games will be suspended when using the configured hotkey.</sys:String>
+    <sys:String x:Key="LOCPlayState_PlaytimeSuspendRemovedResultsMessage">Removed configuration to force to only suspend playtime when using the configured hotkey from {0} game(s).</sys:String>
+    <sys:String x:Key="LOCPlayState_ProcessesSuspendAddedResultsMessage">Configured {0} game(s) to force to suspend playtime and processes when using the configured hotkey.</sys:String>
+    <sys:String x:Key="LOCPlayState_ProcessesSuspendRemovedResultsMessage">Removed configuration to force to suspend playtime and processes when using the configured hotkey from {0} game(s).</sys:String>
     <sys:String x:Key="LOCPlayState_StatusSuspendedMessage">Game suspended</sys:String>
     <sys:String x:Key="LOCPlayState_StatusResumedMessage">Game resumed</sys:String>
     <sys:String x:Key="LOCPlayState_StatusPlaytimeSuspendedMessage">Playtime suspended</sys:String>
@@ -41,7 +43,8 @@ For better compatibility with games, some adjustments to your Windows configurat
     <sys:String x:Key="LOCPlayState_SettingGlobalOnlySuspendPlaytimeLabel">Only suspend playtime count globally and not the game processes</sys:String>
     <sys:String x:Key="LOCPlayState_SettingGlobalOnlySuspendPlaytimeTooltip" xml:space="preserve">By enabling this option, all games won't be suspended when using the configured hotkey and only the time will be counted to substracted from the game playtime when it stops.
     
-This can also be applied individually per game by adding a feature named "[PlayState] Suspend playtime only" to a game</sys:String>
+This can also be applied individually per game by adding a feature named "[PlayState] Suspend playtime only" to a game, if you want to have this setting enabled in that game,
+or a feature named "[PlayState] Suspend processes", if you want to have it disabled on that game.</sys:String>
     <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleLabel">Show native Windows notifications instead of Playnite notification window</sys:String>
     <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleTooltip">By enabling this option, games will show native Windows notifications instead of Playnite notification window.</sys:String>
     <sys:String x:Key="LOCPlayState_SettingNotificationShowSessionPlaytime">Display session playtime in notification message</sys:String>

--- a/source/Generic/PlayState/Localization/en_US.xaml
+++ b/source/Generic/PlayState/Localization/en_US.xaml
@@ -2,17 +2,17 @@
     <sys:String x:Key="LOCPlayState_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCPlayState_MenuItemAddToBlacklistDescription">Add selected games to PlayState Blacklist</sys:String>
     <sys:String x:Key="LOCPlayState_MenuItemRemoveFromBlacklistDescription">Remove selected games from Playstate Blacklist</sys:String>
-    <sys:String x:Key="LOCPlayState_MenuItemAddToPlaytimeSuspendDescription">Configure selected games to override suspend playtime only setting</sys:String>
-    <sys:String x:Key="LOCPlayState_MenuItemRemoveFromPlaytimeSuspendDescription">Remove configuration to override suspend playtime only setting</sys:String>
+    <sys:String x:Key="LOCPlayState_MenuItemAddToPlaytimeSuspendDescription">Configure selected games to force to only suspend playtime</sys:String>
+    <sys:String x:Key="LOCPlayState_MenuItemRemoveFromPlaytimeSuspendDescription">Remove configuration to force to only suspend playtime</sys:String>
     <sys:String x:Key="LOCPlayState_NotificationMessageHotkeyRegisterFailed" xml:space="preserve">Failed to register configured Hotkey {0}
 
 You can try using a diferent HotKey combination to possibly fix the issue</sys:String>
     <sys:String x:Key="LOCPlayState_BlacklistAddedResultsMessage">Added {0} game(s) to the PlayState blacklist.</sys:String>
     <sys:String x:Key="LOCPlayState_BlacklistRemovedResultsMessage">Removed {0} game(s) from the PlayState blacklist.</sys:String>
-    <sys:String x:Key="LOCPlayState_PlaytimeSuspendAddedResultsMessage">Configured {0} game(s) to override suspend playtime only setting when using the configured hotkey.</sys:String>
-    <sys:String x:Key="LOCPlayState_PlaytimeSuspendRemovedResultsMessage" xml:space="preserve">Removed configuration to override suspend playtime only setting when using the configured hotkey from {0} game(s).
+    <sys:String x:Key="LOCPlayState_PlaytimeSuspendAddedResultsMessage">Configured {0} game(s) to force to only suspend playtime when using the configured hotkey.</sys:String>
+    <sys:String x:Key="LOCPlayState_PlaytimeSuspendRemovedResultsMessage" xml:space="preserve">Removed configuration to force to only suspend playtime when using the configured hotkey from {0} game(s).
 
-Games will respect the state of the global setting of only suspend playtime count globally and not the game processes.</sys:String>
+Games will be suspended when using the configured hotkey.</sys:String>
     <sys:String x:Key="LOCPlayState_StatusSuspendedMessage">Game suspended</sys:String>
     <sys:String x:Key="LOCPlayState_StatusResumedMessage">Game resumed</sys:String>
     <sys:String x:Key="LOCPlayState_StatusPlaytimeSuspendedMessage">Playtime suspended</sys:String>
@@ -31,10 +31,6 @@ Changing this setting requires restart.</sys:String>
     <sys:String x:Key="LOCPlayState_SettingsWinNotificationNote" xml:space="preserve">If you have Focus Assist enabled when playing a game and fullscreen mode, you have to add Playnite to priority list in order to receive Windows notifications and configure them to allow to display them.
 
 This feature is only supported on Windows 10 and Windows 11</sys:String>
-    <sys:String x:Key="LOCPlayState_MessageSuspPlaytimeOnlyMigration" xml:space="preserve">PlayState has modified the behaviour of the game feature previously called "[PlayState] Suspend Playtime only". This feature is now called "[PlayState] Override suspend playtime only setting".
-
-With this new game feature, the games that have it will override the state of "Only suspend playtime count globally and not the game processes" setting, and so will do the opposite of that setting.
-So if that setting is enabled and this feature is added, that game will suspend playtime and the game processes, and if that setting is disabled and this feature added, will only suspend playtime and not the game processes.</sys:String>
     <sys:String x:Key="LOCPlayState_MessageWinStyleNotificationsFirstSetup" xml:space="preserve">PlayState has added support to display notifications as native windows notifications. This is enabled by default and can be changed from the extension settings.
 
 For better compatibility with games, some adjustments to your Windows configuration is required. A link that contains the the instructions for this will be opened after closing this dialog.</sys:String>
@@ -45,8 +41,7 @@ For better compatibility with games, some adjustments to your Windows configurat
     <sys:String x:Key="LOCPlayState_SettingGlobalOnlySuspendPlaytimeLabel">Only suspend playtime count globally and not the game processes</sys:String>
     <sys:String x:Key="LOCPlayState_SettingGlobalOnlySuspendPlaytimeTooltip" xml:space="preserve">By enabling this option, all games won't be suspended when using the configured hotkey and only the time will be counted to substracted from the game playtime when it stops.
     
-The state of this setting can be overridden individually per game by adding a feature named "[PlayState] Override suspend playtime only setting" to a game.
-If this feature is added, the behaviour of the pause / resume of the game will be the opposite of the state of this setting.</sys:String>
+This can also be applied individually per game by adding a feature named "[PlayState] Suspend playtime only" to a game</sys:String>
     <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleLabel">Show native Windows notifications instead of Playnite notification window</sys:String>
     <sys:String x:Key="LOCPlayState_SettingGlobalShowWindowsNotificationsStyleTooltip">By enabling this option, games will show native Windows notifications instead of Playnite notification window.</sys:String>
     <sys:String x:Key="LOCPlayState_SettingNotificationShowSessionPlaytime">Display session playtime in notification message</sys:String>

--- a/source/Generic/PlayState/Models/PlayStateData.cs
+++ b/source/Generic/PlayState/Models/PlayStateData.cs
@@ -16,8 +16,9 @@ namespace PlayState.Models
         public List<ProcessItem> GameProcesses { get; set; }
         public bool IsSuspended { get; set; }
         public bool ProcessesSuspended { get; set; }
+        public bool SuspendPlaytimeOnly { get; set; }
 
-        public PlayStateData(Game game, List<ProcessItem> gameProcesses)
+        public PlayStateData(Game game, List<ProcessItem> gameProcesses, bool suspendPlaytimeOnly)
         {
             Game = game;
             StartDate = DateTime.Now;
@@ -25,6 +26,7 @@ namespace PlayState.Models
             GameProcesses = gameProcesses;
             IsSuspended = false;
             ProcessesSuspended = false;
+            SuspendPlaytimeOnly = suspendPlaytimeOnly;
         }
     }
 }

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -38,7 +38,6 @@ namespace PlayState
         private List<string> exclusionList;
         private Window currentSplashWindow;
         private DispatcherTimer timer;
-        private bool suspendPlaytimeOnly = false;
         private Window mainWindow;
         private WindowInteropHelper windowInterop;
         private IntPtr mainWindowHandle;
@@ -311,16 +310,14 @@ namespace PlayState
 
             List<ProcessItem> gameProcesses;
 
-            suspendPlaytimeOnly = false;
             var ignoreSuspendPlaytimeSetting = game.Features != null ? game.Features.Any(a => a.Name.Equals("[PlayState] Override suspend playtime only setting", StringComparison.OrdinalIgnoreCase)) : false;
             if (settings.Settings.SubstractSuspendedPlaytimeOnStopped &&
                 (settings.Settings.GlobalOnlySuspendPlaytime && !ignoreSuspendPlaytimeSetting ||
                 !settings.Settings.GlobalOnlySuspendPlaytime && ignoreSuspendPlaytimeSetting))
             {
-                suspendPlaytimeOnly = true;
                 currentGame = game;
                 gameProcesses = null;
-                AddGame(game, gameProcesses);
+                AddGame(game, gameProcesses, true);
                 return;
             }
 
@@ -649,7 +646,7 @@ namespace PlayState
                     gameData.ProcessesSuspended = true;
                 }
 
-                if (gameData.ProcessesSuspended || suspendPlaytimeOnly)
+                if (gameData.ProcessesSuspended || gameData.SuspendPlaytimeOnly)
                 {
                     if (gameData.IsSuspended)
                     {
@@ -800,7 +797,7 @@ namespace PlayState
             RemoveGame(game);
         }
 
-        private void AddGame(Game game, List<ProcessItem> gameProcesses)
+        private void AddGame(Game game, List<ProcessItem> gameProcesses, bool suspendPlaytimeOnly = false)
         {
             if (playStateData.Any(x => x.Game.Id == game.Id))
             {
@@ -808,7 +805,7 @@ namespace PlayState
             }
             else
             {
-                playStateData.Add(new PlayStateData(game, gameProcesses));
+                playStateData.Add(new PlayStateData(game, gameProcesses, suspendPlaytimeOnly));
                 var procsExecutablePaths = string.Join(", ", gameProcesses.Select(x => x.ExecutablePath));
                 logger.Debug($"Data for game {game.Name} with id {game.Id} was created. Executables: {procsExecutablePaths}");
             }

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -302,9 +302,11 @@ namespace PlayState
 
             List<ProcessItem> gameProcesses;
 
+            var suspendPlaytimeOnlyFeature = game.Features != null ? game.Features.Any(a => a.Name.Equals("[PlayState] Suspend Playtime only", StringComparison.OrdinalIgnoreCase)) : false;
+            var suspendProcessesFeature = game.Features != null ? game.Features.Any(a => a.Name.Equals("[PlayState] Suspend Processes", StringComparison.OrdinalIgnoreCase)) : false;
             if (settings.Settings.SubstractSuspendedPlaytimeOnStopped &&
-                (settings.Settings.GlobalOnlySuspendPlaytime ||
-                game.Features != null && game.Features.Any(a => a.Name.Equals("[PlayState] Suspend Playtime only", StringComparison.OrdinalIgnoreCase))))
+                (settings.Settings.GlobalOnlySuspendPlaytime && !suspendProcessesFeature ||
+                !settings.Settings.GlobalOnlySuspendPlaytime && suspendPlaytimeOnlyFeature))
             {
                 currentGame = game;
                 gameProcesses = null;
@@ -870,6 +872,24 @@ namespace PlayState
                     Action = a => {
                         var featureRemovedCount = PlayniteUtilities.RemoveFeatureFromGames(PlayniteApi, PlayniteApi.MainView.SelectedGames.Distinct(), "[PlayState] Suspend Playtime only");
                         PlayniteApi.Dialogs.ShowMessage(string.Format(ResourceProvider.GetString("LOCPlayState_PlaytimeSuspendRemovedResultsMessage"), featureRemovedCount), "PlayState");
+                    }
+                },
+                new MainMenuItem
+                {
+                    Description = ResourceProvider.GetString("LOCPlayState_MenuItemAddToProcessesSuspendDescription"),
+                    MenuSection = "@PlayState",
+                    Action = a => {
+                        var featureAddedCount = PlayniteUtilities.AddFeatureToGames(PlayniteApi, PlayniteApi.MainView.SelectedGames.Distinct(), "[PlayState] Suspend Processes");
+                        PlayniteApi.Dialogs.ShowMessage(string.Format(ResourceProvider.GetString("LOCPlayState_ProcessesSuspendAddedResultsMessage"), featureAddedCount), "PlayState");
+                    }
+                },
+                new MainMenuItem
+                {
+                    Description = ResourceProvider.GetString("LOCPlayState_MenuItemRemoveFromProcessesSuspendDescription"),
+                    MenuSection = "@PlayState",
+                    Action = a => {
+                        var featureRemovedCount = PlayniteUtilities.RemoveFeatureFromGames(PlayniteApi, PlayniteApi.MainView.SelectedGames.Distinct(), "[PlayState] Suspend Processes");
+                        PlayniteApi.Dialogs.ShowMessage(string.Format(ResourceProvider.GetString("LOCPlayState_ProcessesSuspendRemovedResultsMessage"), featureRemovedCount), "PlayState");
                     }
                 }
             };

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -120,6 +120,14 @@ namespace PlayState
                     .Show();
                 ProcessStarter.StartUrl(@"https://github.com/darklinkpower/PlayniteExtensionsCollection/wiki/PlayState#window-notification-style-configuration");
             }
+
+            var suspendPlaytimeOnlyFeature = PlayniteApi.Database.Features.FirstOrDefault(a => a.Name.Equals("[PlayState] Suspend Playtime only", StringComparison.OrdinalIgnoreCase));
+            if (suspendPlaytimeOnlyFeature != null)
+            {
+                suspendPlaytimeOnlyFeature.Name = "[PlayState] Override suspend playtime only setting";
+                PlayniteApi.Database.Features.Update(suspendPlaytimeOnlyFeature);
+                PlayniteApi.Dialogs.ShowMessage(ResourceProvider.GetString("LOCPlayState_MessageSuspPlaytimeOnlyMigration"), "PlayState");
+            }
         }
 
         internal bool RegisterGlobalHotkey()
@@ -304,9 +312,10 @@ namespace PlayState
             List<ProcessItem> gameProcesses;
 
             suspendPlaytimeOnly = false;
+            var ignoreSuspendPlaytimeSetting = game.Features != null ? game.Features.Any(a => a.Name.Equals("[PlayState] Override suspend playtime only setting", StringComparison.OrdinalIgnoreCase)) : false;
             if (settings.Settings.SubstractSuspendedPlaytimeOnStopped &&
-                (settings.Settings.GlobalOnlySuspendPlaytime ||
-                game.Features != null && game.Features.Any(a => a.Name.Equals("[PlayState] Suspend Playtime only", StringComparison.OrdinalIgnoreCase))))
+                (settings.Settings.GlobalOnlySuspendPlaytime && !ignoreSuspendPlaytimeSetting ||
+                !settings.Settings.GlobalOnlySuspendPlaytime && ignoreSuspendPlaytimeSetting))
             {
                 suspendPlaytimeOnly = true;
                 currentGame = game;
@@ -862,7 +871,7 @@ namespace PlayState
                     Description = ResourceProvider.GetString("LOCPlayState_MenuItemAddToPlaytimeSuspendDescription"),
                     MenuSection = "@PlayState",
                     Action = a => {
-                        var featureAddedCount = PlayniteUtilities.AddFeatureToGames(PlayniteApi, PlayniteApi.MainView.SelectedGames.Distinct(), "[PlayState] Suspend Playtime only");
+                        var featureAddedCount = PlayniteUtilities.AddFeatureToGames(PlayniteApi, PlayniteApi.MainView.SelectedGames.Distinct(), "[PlayState] Override suspend playtime only setting");
                         PlayniteApi.Dialogs.ShowMessage(string.Format(ResourceProvider.GetString("LOCPlayState_PlaytimeSuspendAddedResultsMessage"), featureAddedCount), "PlayState");
                     }
                 },
@@ -871,7 +880,7 @@ namespace PlayState
                     Description = ResourceProvider.GetString("LOCPlayState_MenuItemRemoveFromPlaytimeSuspendDescription"),
                     MenuSection = "@PlayState",
                     Action = a => {
-                        var featureRemovedCount = PlayniteUtilities.RemoveFeatureFromGames(PlayniteApi, PlayniteApi.MainView.SelectedGames.Distinct(), "[PlayState] Suspend Playtime only");
+                        var featureRemovedCount = PlayniteUtilities.RemoveFeatureFromGames(PlayniteApi, PlayniteApi.MainView.SelectedGames.Distinct(), "[PlayState] Override suspend playtime only setting");
                         PlayniteApi.Dialogs.ShowMessage(string.Format(ResourceProvider.GetString("LOCPlayState_PlaytimeSuspendRemovedResultsMessage"), featureRemovedCount), "PlayState");
                     }
                 }

--- a/source/Generic/PlayState/PlayState.cs
+++ b/source/Generic/PlayState/PlayState.cs
@@ -119,14 +119,6 @@ namespace PlayState
                     .Show();
                 ProcessStarter.StartUrl(@"https://github.com/darklinkpower/PlayniteExtensionsCollection/wiki/PlayState#window-notification-style-configuration");
             }
-
-            var suspendPlaytimeOnlyFeature = PlayniteApi.Database.Features.FirstOrDefault(a => a.Name.Equals("[PlayState] Suspend Playtime only", StringComparison.OrdinalIgnoreCase));
-            if (suspendPlaytimeOnlyFeature != null)
-            {
-                suspendPlaytimeOnlyFeature.Name = "[PlayState] Override suspend playtime only setting";
-                PlayniteApi.Database.Features.Update(suspendPlaytimeOnlyFeature);
-                PlayniteApi.Dialogs.ShowMessage(ResourceProvider.GetString("LOCPlayState_MessageSuspPlaytimeOnlyMigration"), "PlayState");
-            }
         }
 
         internal bool RegisterGlobalHotkey()
@@ -310,10 +302,9 @@ namespace PlayState
 
             List<ProcessItem> gameProcesses;
 
-            var ignoreSuspendPlaytimeSetting = game.Features != null ? game.Features.Any(a => a.Name.Equals("[PlayState] Override suspend playtime only setting", StringComparison.OrdinalIgnoreCase)) : false;
             if (settings.Settings.SubstractSuspendedPlaytimeOnStopped &&
-                (settings.Settings.GlobalOnlySuspendPlaytime && !ignoreSuspendPlaytimeSetting ||
-                !settings.Settings.GlobalOnlySuspendPlaytime && ignoreSuspendPlaytimeSetting))
+                (settings.Settings.GlobalOnlySuspendPlaytime ||
+                game.Features != null && game.Features.Any(a => a.Name.Equals("[PlayState] Suspend Playtime only", StringComparison.OrdinalIgnoreCase))))
             {
                 currentGame = game;
                 gameProcesses = null;
@@ -868,7 +859,7 @@ namespace PlayState
                     Description = ResourceProvider.GetString("LOCPlayState_MenuItemAddToPlaytimeSuspendDescription"),
                     MenuSection = "@PlayState",
                     Action = a => {
-                        var featureAddedCount = PlayniteUtilities.AddFeatureToGames(PlayniteApi, PlayniteApi.MainView.SelectedGames.Distinct(), "[PlayState] Override suspend playtime only setting");
+                        var featureAddedCount = PlayniteUtilities.AddFeatureToGames(PlayniteApi, PlayniteApi.MainView.SelectedGames.Distinct(), "[PlayState] Suspend Playtime only");
                         PlayniteApi.Dialogs.ShowMessage(string.Format(ResourceProvider.GetString("LOCPlayState_PlaytimeSuspendAddedResultsMessage"), featureAddedCount), "PlayState");
                     }
                 },
@@ -877,7 +868,7 @@ namespace PlayState
                     Description = ResourceProvider.GetString("LOCPlayState_MenuItemRemoveFromPlaytimeSuspendDescription"),
                     MenuSection = "@PlayState",
                     Action = a => {
-                        var featureRemovedCount = PlayniteUtilities.RemoveFeatureFromGames(PlayniteApi, PlayniteApi.MainView.SelectedGames.Distinct(), "[PlayState] Override suspend playtime only setting");
+                        var featureRemovedCount = PlayniteUtilities.RemoveFeatureFromGames(PlayniteApi, PlayniteApi.MainView.SelectedGames.Distinct(), "[PlayState] Suspend Playtime only");
                         PlayniteApi.Dialogs.ShowMessage(string.Format(ResourceProvider.GetString("LOCPlayState_PlaytimeSuspendRemovedResultsMessage"), featureRemovedCount), "PlayState");
                     }
                 }


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.

Divided in 2 commits to ease the review.

1st commit (Added override suspend playtime only setting):
- Replaced "[PlayState] Suspend playtime only" feature with "[PlayState] Override suspend playtime only setting"
This will make that you can enable the option of "Only suspend playtime count globally and not the game processes" and select a few games to pause playtime and game processes, and the opposite, disable that option and select a few games to only pause playtime.
- Migrate the previous feature to the new, and add a message to the user so they know that the new feature behave on a different way than the previous one.

![image](https://user-images.githubusercontent.com/11770760/160244024-d18e7eb0-849a-45ea-93f3-f15facab042c.png)

2nd commit (Set suspendPlaytimeOnly variable in PlayStateData):
- Set the variable "suspendPlaytimeOnly" by game and not globally, since some games could have it enabled and others disabled. This fixes a bug that caused that when you launched a game that have it enabled, and after that launched a game that have it disabled, when closing the second game the first game couldn't be paused anymore.