### PR TITLE
Video player improvements

### DIFF
--- a/source/Generic/ExtraMetadataLoader/Controls/VideoPlayerControl.xaml
+++ b/source/Generic/ExtraMetadataLoader/Controls/VideoPlayerControl.xaml
@@ -122,7 +122,8 @@
                     <Grid Name="SliderGrid" Grid.Column="0" Margin="0,0,10,0">
                         <ProgressBar x:Name="playbackProgressBar" Height="20" Padding="0" Width="{Binding ElementName=SliderGrid, Path=Width}"/>
                         <Slider x:Name="timelineSlider" Height="{Binding ElementName=playbackProgressBar, Path=ActualHeight}" IsMoveToPointEnabled="True" Width="{Binding ElementName=SliderGrid, Path=Width}" VerticalAlignment="Center"
-                                Thumb.DragStarted="timelineSlider_DragStarted" Thumb.DragCompleted="timelineSlider_DragCompleted" />
+                                Thumb.DragStarted="timelineSlider_DragStarted" Thumb.DragCompleted="timelineSlider_DragCompleted" 
+                                PreviewMouseUp="timelineSlider_PreviewMouseUp"/>
                     </Grid>
                     <DockPanel Grid.Column="1" Visibility="{Binding IsSoundEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <TextBlock DockPanel.Dock="Left" Text="&#xEC94;" FontSize="24" FontFamily="{StaticResource FontIcoFont}" VerticalAlignment="Center" Margin="0,0,8,0"/>

--- a/source/Generic/ExtraMetadataLoader/Controls/VideoPlayerControl.xaml
+++ b/source/Generic/ExtraMetadataLoader/Controls/VideoPlayerControl.xaml
@@ -5,7 +5,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:ExtraMetadataLoader"
              mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+             d:DesignHeight="450" d:DesignWidth="800"
+             d:DataContext="{d:DesignInstance IsDesignTimeCreatable=False, Type=local:VideoPlayerControl}">
     <Grid Name="ControlGrid" Visibility="{Binding ControlVisibility}" MinHeight="120">
         <Grid>
             <Grid.Style>
@@ -125,7 +126,7 @@
                     </Grid>
                     <DockPanel Grid.Column="1" Visibility="{Binding IsSoundEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <TextBlock DockPanel.Dock="Left" Text="&#xEC94;" FontSize="24" FontFamily="{StaticResource FontIcoFont}" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                        <Slider DockPanel.Dock="Left" Name="volumeSlider" VerticalAlignment="Center" VerticalContentAlignment="Center"
+                        <Slider DockPanel.Dock="Left" Name="volumeSlider" VerticalAlignment="Center" VerticalContentAlignment="Center" Value="{Binding VideoPlayerVolumeLinear}"
                                 Minimum="0" Maximum="1" IsSnapToTickEnabled="True" TickFrequency="0.025"/>
                     </DockPanel>
                 </Grid>

--- a/source/Generic/ExtraMetadataLoader/Controls/VideoPlayerControl.xaml.cs
+++ b/source/Generic/ExtraMetadataLoader/Controls/VideoPlayerControl.xaml.cs
@@ -104,6 +104,17 @@ namespace ExtraMetadataLoader
             }
         }
 
+        public double VideoPlayerVolumeLinear
+        {
+            get => Math.Sqrt(videoPlayerVolume);
+            set
+            {
+                videoPlayerVolume = value * value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(VideoPlayerVolume));
+            }
+        }
+
         private double videoPlayerVolume;
         public double VideoPlayerVolume
         {
@@ -112,6 +123,7 @@ namespace ExtraMetadataLoader
             {
                 videoPlayerVolume = value * value;
                 OnPropertyChanged();
+                OnPropertyChanged(nameof(VideoPlayerVolumeLinear));
             }
         }
 
@@ -173,7 +185,6 @@ namespace ExtraMetadataLoader
                 ActiveViewAtCreation = PlayniteApi.MainView.ActiveDesktopView;
             }
 
-            volumeSlider.ValueChanged += VolumeSlider_ValueChanged;
             timer = new DispatcherTimer();
             timer.Interval = TimeSpan.FromMilliseconds(250);
             timer.Tick += new EventHandler(timer_Tick);
@@ -221,11 +232,6 @@ namespace ExtraMetadataLoader
 
             PlaybackTimeProgress = player.Position.ToString(@"mm\:ss") ?? "00:00";
             playbackProgressBar.Value = player.Position.TotalSeconds;
-        }
-
-        private void VolumeSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
-        {
-            VideoPlayerVolume = e.NewValue;
         }
 
         private void timelineSlider_DragStarted(object sender, DragStartedEventArgs e)

--- a/source/Generic/ExtraMetadataLoader/Controls/VideoPlayerControl.xaml.cs
+++ b/source/Generic/ExtraMetadataLoader/Controls/VideoPlayerControl.xaml.cs
@@ -245,6 +245,15 @@ namespace ExtraMetadataLoader
             player.Position = TimeSpan.FromSeconds(timelineSlider.Value);
         }
 
+        private void timelineSlider_PreviewMouseUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (!isDragging)
+            {
+                var delta = e.GetPosition(timelineSlider).X / timelineSlider.ActualWidth;
+                player.Position = TimeSpan.FromSeconds(timelineSlider.Maximum * delta - timelineSlider.Minimum);
+            }
+        }
+
         public RelayCommand<object> VideoPlayCommand
         {
             get => new RelayCommand<object>((a) =>

--- a/source/Generic/ExtraMetadataLoader/Controls/VideoPlayerControl.xaml.cs
+++ b/source/Generic/ExtraMetadataLoader/Controls/VideoPlayerControl.xaml.cs
@@ -250,7 +250,10 @@ namespace ExtraMetadataLoader
             if (!isDragging)
             {
                 var delta = e.GetPosition(timelineSlider).X / timelineSlider.ActualWidth;
-                player.Position = TimeSpan.FromSeconds(timelineSlider.Maximum * delta - timelineSlider.Minimum);
+                if (player.NaturalDuration.HasTimeSpan)
+                {
+                    player.Position = TimeSpan.FromSeconds(timelineSlider.Maximum * delta - timelineSlider.Minimum);
+                }
             }
         }
 


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.

- Added a new VideoPlayerVolumeLinear property that converts the value of VideoPlayerVolume such that it can be bound to sliders directly in TwoWay-Mode.
- Clicking on the timeline without dragging also sets the video position to the clicked position on the slider.