### PR TITLE
fix: CanExectute for Play/Pause command not updating

### DIFF
--- a/source/Generic/ExtraMetadataLoader/Controls/VideoPlayerControl.xaml.cs
+++ b/source/Generic/ExtraMetadataLoader/Controls/VideoPlayerControl.xaml.cs
@@ -270,6 +270,9 @@ namespace ExtraMetadataLoader
             player.Play();
             timer.Start();
             SettingsModel.Settings.IsVideoPlaying = true;
+
+            OnPropertyChanged(nameof(VideoPlayCommand));
+            OnPropertyChanged(nameof(VideoPauseCommand));
         }
 
         public RelayCommand<object> VideoPauseCommand
@@ -285,6 +288,9 @@ namespace ExtraMetadataLoader
             player.Pause();
             timer.Stop();
             SettingsModel.Settings.IsVideoPlaying = false;
+
+            OnPropertyChanged(nameof(VideoPlayCommand));
+            OnPropertyChanged(nameof(VideoPauseCommand));
         }
 
         public RelayCommand<object> VideoMuteCommand
@@ -347,6 +353,9 @@ namespace ExtraMetadataLoader
                 playbackProgressBar.Maximum = ts.TotalSeconds;
                 PlaybackTimeTotal = ts.ToString(@"mm\:ss");
             }
+
+            OnPropertyChanged(nameof(VideoPlayCommand));
+            OnPropertyChanged(nameof(VideoPauseCommand));
         }
 
         private void player_MediaEnded(object sender, EventArgs e)
@@ -363,6 +372,9 @@ namespace ExtraMetadataLoader
                 timer.Stop();
                 SettingsModel.Settings.IsVideoPlaying = false;
             }
+
+            OnPropertyChanged(nameof(VideoPlayCommand));
+            OnPropertyChanged(nameof(VideoPauseCommand));
         }
 
         public void ResetPlayerValues()
@@ -381,6 +393,9 @@ namespace ExtraMetadataLoader
             microVideoPath = null;
             trailerVideoPath = null;
             multipleSourcesAvailable = false;
+
+            OnPropertyChanged(nameof(VideoPlayCommand));
+            OnPropertyChanged(nameof(VideoPauseCommand));
         }
 
         public override void GameContextChanged(Game oldContext, Game newContext)
@@ -435,6 +450,9 @@ namespace ExtraMetadataLoader
                 SettingsModel.Settings.IsVideoPlaying = false;
             }
             ControlVisibility = Visibility.Visible;
+
+            OnPropertyChanged(nameof(VideoPlayCommand));
+            OnPropertyChanged(nameof(VideoPauseCommand));
         }
 
         public void UpdateGameVideoSources()


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.

I added OnPropertyChanged() for the Play and Pause commands in various places. On some paths this might call it multiple times, but that shouldn't be a problem. This ensures that elements are enabled/disabled properly when bound to that command.