### PR TITLE
[PlayState] Added reminder if currentGame is paused

### DIFF
--- a/source/Generic/PlayState/Localization/en_US.xaml
+++ b/source/Generic/PlayState/Localization/en_US.xaml
@@ -58,6 +58,7 @@ This mode can also be changed individually per game by using the extensions func
     <sys:String x:Key="LOCPlayState_Setting_SuspendModeLabel">Suspend mode:</sys:String>
     <sys:String x:Key="LOCPlayState_SettingNotificationShowSessionPlaytime">Display session playtime in notification message</sys:String>
     <sys:String x:Key="LOCPlayState_SettingNotificationShowTotalPlaytime">Display total playtime in notification message</sys:String>
+    <sys:String x:Key="LOCPlayState_SettingNotificationShowSuspendedReminders">Display a notification reminder if the current game has been suspended for more than x minutes</sys:String>
     <sys:String x:Key="LOCPlayState_SettingUseForegroundAutomaticSuspend">Automatically suspend games if they are not the active window</sys:String>
     <sys:String x:Key="LOCPlayState_SettingUseForegroundAutomaticSuspendNote" xml:space="preserve">This functionality will work differently depending on the suspend mode of the running game.
 

--- a/source/Generic/PlayState/Models/PlayStateData.cs
+++ b/source/Generic/PlayState/Models/PlayStateData.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Threading;
 
 namespace PlayState.Models
 {
@@ -20,6 +21,8 @@ namespace PlayState.Models
         public DateTime StartDate { get; } = DateTime.Now;
         private Stopwatch stopwatch = new Stopwatch();
         public Stopwatch Stopwatch { get => stopwatch; set => SetValue(ref stopwatch, value); }
+        private DispatcherTimer reminderTimer = new DispatcherTimer();
+        public DispatcherTimer ReminderTimer { get => reminderTimer; set => SetValue(ref reminderTimer, value); }
         public List<ProcessItem> GameProcesses { get; set; }
         public bool HasProcesses => GameProcesses?.HasItems() == true;
 

--- a/source/Generic/PlayState/Models/PlayStateData.cs
+++ b/source/Generic/PlayState/Models/PlayStateData.cs
@@ -89,5 +89,19 @@ namespace PlayState.Models
                 GameProcesses = null;
             }
         }
+
+        public void SetReminderTimer()
+        {
+            if (ReminderTimer.IsEnabled)
+            {
+                ReminderTimer.Stop();
+            }
+            else
+            {
+                ReminderTimer = new DispatcherTimer();
+                ReminderTimer.Interval = TimeSpan.FromMinutes(1);
+                ReminderTimer.Start();
+            }
+        }
     }
 }

--- a/source/Generic/PlayState/PlayStateSettings.cs
+++ b/source/Generic/PlayState/PlayStateSettings.cs
@@ -59,6 +59,9 @@ namespace PlayState
         private bool notificationShowTotalPlaytime = true;
         public bool NotificationShowTotalPlaytime { get => notificationShowTotalPlaytime; set => SetValue(ref notificationShowTotalPlaytime, value); }
         public bool WindowsNotificationStyleFirstSetupDone = false;
+        [DontSerialize]
+        private bool notificationShowSuspendedReminder = false;
+        public bool NotificationShowSuspendedReminder { get => notificationShowSuspendedReminder; set => SetValue(ref notificationShowSuspendedReminder, value); }
 
         [DontSerialize]
         private bool showManagerSidebarItem = true;

--- a/source/Generic/PlayState/PlayStateSettingsView.xaml
+++ b/source/Generic/PlayState/PlayStateSettingsView.xaml
@@ -330,6 +330,9 @@
                         <CheckBox Content="{DynamicResource LOCPlayState_SettingNotificationShowTotalPlaytime}"
                               IsChecked="{Binding Settings.NotificationShowTotalPlaytime}"
                               Margin="0,10,0,0"/>
+                        <CheckBox Content="{DynamicResource LOCPlayState_SettingNotificationShowSuspendedReminders}"
+                              IsChecked="{Binding Settings.NotificationShowSuspendedReminder}"
+                              Margin="0,10,0,0"/>
 
                     </StackPanel>
                 </StackPanel>

--- a/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
+++ b/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
@@ -415,7 +415,6 @@ namespace PlayState.ViewModels
                 }
 
                 var notificationType = NotificationTypes.None;
-                var reminder = true;
                 if (processesSuspended || gameData.SuspendMode == SuspendModes.Playtime)
                 {
                     if (gameData.IsSuspended)
@@ -424,7 +423,7 @@ namespace PlayState.ViewModels
                         notificationType = processesSuspended ? NotificationTypes.Resumed : NotificationTypes.PlaytimeResumed;
                         gameData.Stopwatch.Stop();
                         logger.Debug($"Game {gameData.Game.Name} resumed in mode {gameData.SuspendMode}");
-                        if (reminder)
+                        if (settings.Settings.NotificationShowSuspendedReminder)
                         {
                             gameData.SetReminderTimer();
                         }
@@ -434,7 +433,7 @@ namespace PlayState.ViewModels
                         gameData.IsSuspended = true;
                         notificationType = processesSuspended ? NotificationTypes.Suspended : NotificationTypes.PlaytimeSuspended;
                         gameData.Stopwatch.Start();
-                        if (reminder)
+                        if (settings.Settings.NotificationShowSuspendedReminder)
                         {
                             gameData.SetReminderTimer();
                             gameData.ReminderTimer.Tick += (sender, e) => ShowNotificationReminderIfCurrentGameIsSuspended(gameData);

--- a/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
+++ b/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
@@ -426,7 +426,7 @@ namespace PlayState.ViewModels
                         logger.Debug($"Game {gameData.Game.Name} resumed in mode {gameData.SuspendMode}");
                         if (reminder)
                         {
-                            gameData.ReminderTimer.Stop();
+                            gameData.SetReminderTimer();
                         }
                     }
                     else
@@ -436,10 +436,8 @@ namespace PlayState.ViewModels
                         gameData.Stopwatch.Start();
                         if (reminder)
                         {
-                            gameData.ReminderTimer = new DispatcherTimer();
-                            gameData.ReminderTimer.Interval = TimeSpan.FromMinutes(1);
-                            gameData.ReminderTimer.Tick += (sender, e) => ShowNotificationReminderIfCurrentGameIsSuspended(gameData);       
-                            gameData.ReminderTimer.Start();
+                            gameData.SetReminderTimer();
+                            gameData.ReminderTimer.Tick += (sender, e) => ShowNotificationReminderIfCurrentGameIsSuspended(gameData);
                         }
                         logger.Debug($"Game {gameData.Game.Name} suspended in mode {gameData.SuspendMode}");
                     }


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.

-Closes #257 
Opening as draft since I didn't include the settings yet since I want to know first if you like this approach.
The idea is the settings will have an option to enable or disable this, and a slider to choose how often (in minutes) will reminder that the currentGame is paused.

