### PR TITLE
[PlayState] Start monitoring faster games when they will be only suspended by playtime

### DIFF
--- a/source/Generic/PlayState/Models/PlayStateData.cs
+++ b/source/Generic/PlayState/Models/PlayStateData.cs
@@ -79,6 +79,11 @@ namespace PlayState.Models
             settingsModel.Settings.PropertyChanged -= Settings_PropertyChanged;
         }
 
+        public void SetProcesses(List<ProcessItem> gameProcesses)
+        {
+            GameProcesses = gameProcesses;
+        }
+
         internal void RemoveProcesses()
         {
             if (HasProcesses)

--- a/source/Generic/PlayState/PlayState2.cs
+++ b/source/Generic/PlayState/PlayState2.cs
@@ -1,7 +1,6 @@
 ﻿using Playnite.SDK;
 using Playnite.SDK.Events;
 using Playnite.SDK.Models;
-using PlayniteUtilitiesCommon;
 using PlayState.Enums;
 using PlayState.Models;
 using PlayState.Native;
@@ -232,8 +231,6 @@ namespace PlayState
 
         private async Task<bool> ScanGameProcessesFromDirectoryAsync(Game game, string gameInstallDir)
         {
-            var suspendPlaytimeOnly = Settings.Settings.GlobalSuspendMode == SuspendModes.Playtime && !PlayniteUtilities.GetGameHasFeature(game, featureSuspendProcesses, true) || PlayniteUtilities.GetGameHasFeature(game, featureSuspendPlaytime, true);
-
             // Fix for some games that take longer to start, even when already detected as running
             await Task.Delay(20000);
             if (!playStateManager.IsGameBeingDetected(game))
@@ -248,13 +245,6 @@ namespace PlayState
                 logger.Debug($"Found {gameProcesses.Count} game processes in initial WMI query");
                 playStateManager.AddPlayStateData(game, gameProcesses);
                 return true;
-            }
-
-            // No need to wait for the loop if we don't want to suspend processes
-            if (suspendPlaytimeOnly)
-            {
-                playStateManager.AddPlayStateData(game, new List<ProcessItem>());
-                playStateManager.AddGameToDetection(game);
             }
 
             // Waiting is useful for games that use a startup launcher, since
@@ -285,14 +275,7 @@ namespace PlayState
                 if (gameProcesses.Count > 0 && gameProcesses.Any(x => x.Process.MainWindowHandle != IntPtr.Zero))
                 {
                     logger.Debug($"Found {gameProcesses.Count} game processes");
-                    if (suspendPlaytimeOnly)
-                    {
-                        playStateManager.AddGameProcessesToPlayStateData(game, gameProcesses);
-                    }
-                    else
-                    {
-                        playStateManager.AddPlayStateData(game, gameProcesses);
-                    }
+                    playStateManager.AddPlayStateData(game, gameProcesses);
                     return true;
                 }
                 else
@@ -302,10 +285,6 @@ namespace PlayState
             }
 
             logger.Debug("Couldn't find any game process");
-            if (suspendPlaytimeOnly)
-            {
-                return true;
-            }
             return false;
         }
 

--- a/source/Generic/PlayState/PlayState2.cs
+++ b/source/Generic/PlayState/PlayState2.cs
@@ -1,6 +1,7 @@
 ﻿using Playnite.SDK;
 using Playnite.SDK.Events;
 using Playnite.SDK.Models;
+using PlayniteUtilitiesCommon;
 using PlayState.Enums;
 using PlayState.Models;
 using PlayState.Native;
@@ -231,6 +232,8 @@ namespace PlayState
 
         private async Task<bool> ScanGameProcessesFromDirectoryAsync(Game game, string gameInstallDir)
         {
+            var suspendPlaytimeOnly = Settings.Settings.GlobalSuspendMode == SuspendModes.Playtime && !PlayniteUtilities.GetGameHasFeature(game, featureSuspendProcesses, true) || PlayniteUtilities.GetGameHasFeature(game, featureSuspendPlaytime, true);
+
             // Fix for some games that take longer to start, even when already detected as running
             await Task.Delay(20000);
             if (!playStateManager.IsGameBeingDetected(game))
@@ -245,6 +248,13 @@ namespace PlayState
                 logger.Debug($"Found {gameProcesses.Count} game processes in initial WMI query");
                 playStateManager.AddPlayStateData(game, gameProcesses);
                 return true;
+            }
+
+            // No need to wait for the loop if we don't want to suspend processes
+            if (suspendPlaytimeOnly)
+            {
+                playStateManager.AddPlayStateData(game, new List<ProcessItem>());
+                playStateManager.AddGameToDetection(game);
             }
 
             // Waiting is useful for games that use a startup launcher, since
@@ -275,7 +285,14 @@ namespace PlayState
                 if (gameProcesses.Count > 0 && gameProcesses.Any(x => x.Process.MainWindowHandle != IntPtr.Zero))
                 {
                     logger.Debug($"Found {gameProcesses.Count} game processes");
-                    playStateManager.AddPlayStateData(game, gameProcesses);
+                    if (suspendPlaytimeOnly)
+                    {
+                        playStateManager.AddGameProcessesToPlayStateData(game, gameProcesses);
+                    }
+                    else
+                    {
+                        playStateManager.AddPlayStateData(game, gameProcesses);
+                    }
                     return true;
                 }
                 else
@@ -285,6 +302,10 @@ namespace PlayState
             }
 
             logger.Debug("Couldn't find any game process");
+            if (suspendPlaytimeOnly)
+            {
+                return true;
+            }
             return false;
         }
 

--- a/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
+++ b/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
@@ -195,10 +195,13 @@ namespace PlayState.ViewModels
             var data = GetDataOfGame(game);
             if (data != null)
             {
+                // Add processes to the game if the data for this game already exists but doesn't have any processes
+                // This is for games that are added without game processes before going to the WMI loop, but after the loop some processes are detected
                 if (!data.HasProcesses && gameProcesses?.HasItems() == true)
                 {
-                    data.GameProcesses = gameProcesses;
-                    logger.Debug($"Processes for game {game.Name} with id {game.Id} were added. Executables: {procsExecutablePaths}");
+                    data.SetProcesses(gameProcesses);
+                    logger.Debug($"Data for game {game.Name} with id {game.Id} already exists without processes");
+                    logger.Debug($"Found processes for game {game.Name} with id {game.Id} after WMI loop. Executables: {procsExecutablePaths}");
                 }
                 else
                 {

--- a/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
+++ b/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
@@ -189,16 +189,28 @@ namespace PlayState.ViewModels
                 logger.Debug($"Game {game.Name} was no longer being detected when adding PlayState Data");
                 return;
             }
-            
-            if (playStateDataCollection.Any(x => x.Game.Id == game.Id))
-            {
-                logger.Debug($"Data for game {game.Name} with id {game.Id} already exists");
-                return;
-            }
 
-            playStateDataCollection.Add(new PlayStateData(game, gameProcesses, settings));
             var procsExecutablePaths = string.Join(", ", gameProcesses.Select(x => x.ExecutablePath));
-            logger.Debug($"Data for game {game.Name} with id {game.Id} was created. Executables: {procsExecutablePaths}");
+
+            var data = GetDataOfGame(game);
+            if (data != null)
+            {
+                if (!data.HasProcesses && gameProcesses?.HasItems() == true)
+                {
+                    data.GameProcesses = gameProcesses;
+                    logger.Debug($"Processes for game {game.Name} with id {game.Id} were added. Executables: {procsExecutablePaths}");
+                }
+                else
+                {
+                    logger.Debug($"Data for game {game.Name} with id {game.Id} already exists");
+                    return;
+                }
+            }
+            else
+            {
+                playStateDataCollection.Add(new PlayStateData(game, gameProcesses, settings));
+                logger.Debug($"Data for game {game.Name} with id {game.Id} was created. Executables: {procsExecutablePaths}");
+            }
 
             RemoveGameFromDetection(game);
             if (setAsCurrentGame)

--- a/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
+++ b/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
@@ -217,16 +217,6 @@ namespace PlayState.ViewModels
             }
         }
 
-        public void AddGameProcessesToPlayStateData(Game game, List<ProcessItem> gameProcesses)
-        {
-            var data = GetDataOfGame(game);
-            if (data != null)
-            {
-                data.GameProcesses = gameProcesses;
-                var procsExecutablePaths = string.Join(", ", gameProcesses.Select(x => x.ExecutablePath));
-            }
-        }
-
         public void RemovePlayStateData(PlayStateData gameData)
         {
             gameData.Dispose();

--- a/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
+++ b/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
@@ -217,6 +217,16 @@ namespace PlayState.ViewModels
             }
         }
 
+        public void AddGameProcessesToPlayStateData(Game game, List<ProcessItem> gameProcesses)
+        {
+            var data = GetDataOfGame(game);
+            if (data != null)
+            {
+                data.GameProcesses = gameProcesses;
+                var procsExecutablePaths = string.Join(", ", gameProcesses.Select(x => x.ExecutablePath));
+            }
+        }
+
         public void RemovePlayStateData(PlayStateData gameData)
         {
             gameData.Dispose();


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.

Let's see what do you think about this. With this PR, when a game is set to only suspend playtime, it will start monitoring it faster since it will start the detection before going to the big loop. 

Explanation:
Without this PR, Valorant takes 3 minutes to get detected because PlayState for some reason it's not detecting their processes. After this PR, on 20 seconds it's started to monitoring, without processes detected. If eventually some process is found in the loop, it will get added to the game anyway. This only apply for the case of suspend playtime games.

Maybe could be added a setting to enable or disable this.