### PR TITLE
[PlayState] Added suspension / resume override for manual suspension status switch

### DIFF
--- a/source/Generic/PlayState/Enums/AutomaticStateSwitchStatus.cs
+++ b/source/Generic/PlayState/Enums/AutomaticStateSwitchStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace PlayState.Enums
+{
+    public enum PlayStateAutomaticStateSwitchStatus
+    {
+        Enabled = 1,
+        Disabled = 2
+    }
+}

--- a/source/Generic/PlayState/Enums/GameState.cs
+++ b/source/Generic/PlayState/Enums/GameState.cs
@@ -1,8 +1,0 @@
-﻿namespace PlayState.Enums
-{
-    public enum PlayStateGameState
-    {
-        Resumed = 1,
-        Paused = 2
-    }
-}

--- a/source/Generic/PlayState/Enums/GameState.cs
+++ b/source/Generic/PlayState/Enums/GameState.cs
@@ -1,0 +1,8 @@
+﻿namespace PlayState.Enums
+{
+    public enum PlayStateGameState
+    {
+        Resumed = 1,
+        Paused = 2
+    }
+}

--- a/source/Generic/PlayState/Models/PlayStateData.cs
+++ b/source/Generic/PlayState/Models/PlayStateData.cs
@@ -30,8 +30,8 @@ namespace PlayState.Models
         public SuspendModes SuspendMode { get => suspendMode; set => SetValue(ref suspendMode, value); }
         public bool HasBeenInForeground = false;
         public bool IsGameStatusOverrided = false;
-        private PlayStateDataStatus gameStatusOverride;
-        public PlayStateDataStatus GameStatusOverride { get => gameStatusOverride; set => SetValue(ref gameStatusOverride, value); }
+        private PlayStateGameState gameStatusOverride;
+        public PlayStateGameState GameStatusOverride { get => gameStatusOverride; set => SetValue(ref gameStatusOverride, value); }
 
         public PlayStateData(Game game, List<ProcessItem> gameProcesses, PlayStateSettingsViewModel settings)
         {

--- a/source/Generic/PlayState/Models/PlayStateData.cs
+++ b/source/Generic/PlayState/Models/PlayStateData.cs
@@ -30,8 +30,8 @@ namespace PlayState.Models
         public SuspendModes SuspendMode { get => suspendMode; set => SetValue(ref suspendMode, value); }
         public bool HasBeenInForeground = false;
         public bool IsGameStatusOverrided = false;
-        private PlayStateGameState gameStatusOverride;
-        public PlayStateGameState GameStatusOverride { get => gameStatusOverride; set => SetValue(ref gameStatusOverride, value); }
+        private PlayStateAutomaticStateSwitchStatus gameStatusOverride;
+        public PlayStateAutomaticStateSwitchStatus GameStatusOverride { get => gameStatusOverride; set => SetValue(ref gameStatusOverride, value); }
 
         public PlayStateData(Game game, List<ProcessItem> gameProcesses, PlayStateSettingsViewModel settings)
         {

--- a/source/Generic/PlayState/Models/PlayStateData.cs
+++ b/source/Generic/PlayState/Models/PlayStateData.cs
@@ -29,6 +29,9 @@ namespace PlayState.Models
         private SuspendModes suspendMode;
         public SuspendModes SuspendMode { get => suspendMode; set => SetValue(ref suspendMode, value); }
         public bool HasBeenInForeground = false;
+        public bool IsGameStatusOverrided = false;
+        private PlayStateDataStatus gameStatusOverride;
+        public PlayStateDataStatus GameStatusOverride { get => gameStatusOverride; set => SetValue(ref gameStatusOverride, value); }
 
         public PlayStateData(Game game, List<ProcessItem> gameProcesses, PlayStateSettingsViewModel settings)
         {

--- a/source/Generic/PlayState/PlayState.csproj
+++ b/source/Generic/PlayState/PlayState.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Converters\NotificationStyleToStringConverter.cs" />
     <Compile Include="Converters\SuspendModeToStringConverter.cs" />
     <Compile Include="Enums\GamePadToKeyboardHotkeyModes.cs" />
+    <Compile Include="Enums\GameState.cs" />
     <Compile Include="Enums\GameStateSwitchControlState.cs" />
     <Compile Include="Enums\NotificationStyles.cs" />
     <Compile Include="Enums\NotificationTypes.cs" />

--- a/source/Generic/PlayState/PlayState.csproj
+++ b/source/Generic/PlayState/PlayState.csproj
@@ -104,7 +104,7 @@
     <Compile Include="Converters\NotificationStyleToStringConverter.cs" />
     <Compile Include="Converters\SuspendModeToStringConverter.cs" />
     <Compile Include="Enums\GamePadToKeyboardHotkeyModes.cs" />
-    <Compile Include="Enums\GameState.cs" />
+    <Compile Include="Enums\AutomaticStateSwitchStatus.cs" />
     <Compile Include="Enums\GameStateSwitchControlState.cs" />
     <Compile Include="Enums\NotificationStyles.cs" />
     <Compile Include="Enums\NotificationTypes.cs" />

--- a/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
+++ b/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
@@ -122,8 +122,8 @@ namespace PlayState.ViewModels
                 }
 
                 if (playstateData.IsGameStatusOverrided && 
-                    (isForeground && playstateData.GameStatusOverride == PlayStateGameState.Resumed ||
-                    !isForeground && playstateData.GameStatusOverride == PlayStateGameState.Paused))
+                    (isForeground && playstateData.GameStatusOverride == PlayStateAutomaticStateSwitchStatus.Enabled ||
+                    !isForeground && playstateData.GameStatusOverride == PlayStateAutomaticStateSwitchStatus.Disabled))
                 {
                     playstateData.IsGameStatusOverrided = false;
                 }
@@ -433,7 +433,7 @@ namespace PlayState.ViewModels
                         if (isGameStatusOverrided)
                         {
                             gameData.IsGameStatusOverrided = true;
-                            gameData.GameStatusOverride = PlayStateGameState.Resumed;
+                            gameData.GameStatusOverride = PlayStateAutomaticStateSwitchStatus.Enabled;
                         }
                     }
                     else
@@ -445,7 +445,7 @@ namespace PlayState.ViewModels
                         if (isGameStatusOverrided)
                         {
                             gameData.IsGameStatusOverrided = true;
-                            gameData.GameStatusOverride = PlayStateGameState.Paused;
+                            gameData.GameStatusOverride = PlayStateAutomaticStateSwitchStatus.Disabled;
                         }
                     }
                 }

--- a/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
+++ b/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
@@ -122,8 +122,8 @@ namespace PlayState.ViewModels
                 }
 
                 if (playstateData.IsGameStatusOverrided && 
-                    (isForeground && playstateData.GameStatusOverride == PlayStateDataStatus.Running ||
-                    !isForeground && playstateData.GameStatusOverride == PlayStateDataStatus.Paused))
+                    (isForeground && playstateData.GameStatusOverride == PlayStateGameState.Resumed ||
+                    !isForeground && playstateData.GameStatusOverride == PlayStateGameState.Paused))
                 {
                     playstateData.IsGameStatusOverrided = false;
                 }
@@ -433,7 +433,7 @@ namespace PlayState.ViewModels
                         if (isGameStatusOverrided)
                         {
                             gameData.IsGameStatusOverrided = true;
-                            gameData.GameStatusOverride = PlayStateDataStatus.Running;
+                            gameData.GameStatusOverride = PlayStateGameState.Resumed;
                         }
                     }
                     else
@@ -445,7 +445,7 @@ namespace PlayState.ViewModels
                         if (isGameStatusOverrided)
                         {
                             gameData.IsGameStatusOverrided = true;
-                            gameData.GameStatusOverride = PlayStateDataStatus.Paused;
+                            gameData.GameStatusOverride = PlayStateGameState.Paused;
                         }
                     }
                 }

--- a/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
+++ b/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
@@ -121,6 +121,13 @@ namespace PlayState.ViewModels
                     playstateData.HasBeenInForeground = true;
                 }
 
+                if (playstateData.IsGameStatusOverrided && 
+                    (isForeground && playstateData.GameStatusOverride == PlayStateDataStatus.Running ||
+                    !isForeground && playstateData.GameStatusOverride == PlayStateDataStatus.Paused))
+                {
+                    playstateData.IsGameStatusOverrided = false;
+                }
+
                 if (!ContinueAutomaticStateExecution(playstateData, isForeground))
                 {
                     continue;
@@ -128,13 +135,21 @@ namespace PlayState.ViewModels
 
                 if (isForeground == playstateData.IsSuspended)
                 {
-                    SwitchGameState(playstateData);
+                    SwitchGameState(playstateData, false);
                 }
             }
         }
 
         private bool ContinueAutomaticStateExecution(PlayStateData playstateData, bool isForeground)
         {
+            // We check first if the game status has been override, and if so we don't automatically change the state until the override is gone
+            // This is made because if you manually suspend the game, PlayState will automatically resume it again if the game is in the foreground,
+            // or if you manually resume the game, PlayState will automatically suspend it again if the game is not in the foreground.
+            if (playstateData.IsGameStatusOverrided)
+            {
+                return false;
+            }
+
             if (playstateData.SuspendMode != SuspendModes.Processes)
             {
                 return true;
@@ -379,7 +394,7 @@ namespace PlayState.ViewModels
             }
         }
 
-        public bool SwitchGameState(PlayStateData gameData)
+        public bool SwitchGameState(PlayStateData gameData, bool isGameStatusOverrided = true)
         {
             var handled = false;
             try
@@ -415,6 +430,11 @@ namespace PlayState.ViewModels
                         notificationType = processesSuspended ? NotificationTypes.Resumed : NotificationTypes.PlaytimeResumed;
                         gameData.Stopwatch.Stop();
                         logger.Debug($"Game {gameData.Game.Name} resumed in mode {gameData.SuspendMode}");
+                        if (isGameStatusOverrided)
+                        {
+                            gameData.IsGameStatusOverrided = true;
+                            gameData.GameStatusOverride = PlayStateDataStatus.Running;
+                        }
                     }
                     else
                     {
@@ -422,6 +442,11 @@ namespace PlayState.ViewModels
                         notificationType = processesSuspended ? NotificationTypes.Suspended : NotificationTypes.PlaytimeSuspended;
                         gameData.Stopwatch.Start();
                         logger.Debug($"Game {gameData.Game.Name} suspended in mode {gameData.SuspendMode}");
+                        if (isGameStatusOverrided)
+                        {
+                            gameData.IsGameStatusOverrided = true;
+                            gameData.GameStatusOverride = PlayStateDataStatus.Paused;
+                        }
                     }
                 }
 


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.

Current behaviour before this PR:
- When you have enabled the option of automatically suspend / resume a game if is / is not in the foreground, if you manually suspend / resume the game, on the next second it will automatically get reverted.

After this PR:
- If you manually suspend / resume a game, this setting will be overrided until you minimize and restore the game again, so if you pause a game that is on the foreground, it won't get resume unless you manually do so again or after you minimize it and set again to the foreground.

I think this is the expected behaviour, because with the current behaviour manually suspending or resuming a game doesn't have any real impact if you have that setting enabled.

IMO this partially closes #306. Only thing remaining for fully closing that issue would be add support for manually choose the process to watch, so games like Valorant could be tracked with the automatic option, since currently PlayState is not detecting any game processes.