### PR TITLE
update geforce now extension

### DIFF
--- a/source/Library/NVIDIAGeForceNowLibrary/Models/GfnGraphQlResponse.cs
+++ b/source/Library/NVIDIAGeForceNowLibrary/Models/GfnGraphQlResponse.cs
@@ -114,7 +114,8 @@ namespace NVIDIAGeForceNowEnabler.Models
         Unknown = 12,
         Uplay = 13,
         Wargaming = 14,
-        Stove = 15
+        Stove = 15,
+        EA_APP = 16
     };
 
     public enum Status {


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.

Update for Geforce Now Enabler the update database fails at the moment because there's an extra AppStore added