### PR TITLE
Support for ExpandableVariables

### DIFF
--- a/source/Generic/ExtraMetadataLoader/ExtraMetadataLoader.cs
+++ b/source/Generic/ExtraMetadataLoader/ExtraMetadataLoader.cs
@@ -896,33 +896,37 @@ namespace ExtraMetadataLoader
 
         private bool ValidateExecutablesSettings(bool validateFfmpeg, bool validateYtdl)
         {
+            var youtubeDlPath = extraMetadataHelper.ExpandVariables(settings.Settings.YoutubeDlPath);
+            var ffmpegPath = extraMetadataHelper.ExpandVariables(settings.Settings.FfmpegPath);
+            var ffprobePath = extraMetadataHelper.ExpandVariables(settings.Settings.FfprobePath);
+
             var success = true;
             if (validateFfmpeg)
             {
                 // ffmpeg
-                if (settings.Settings.FfmpegPath.IsNullOrEmpty())
+                if (ffmpegPath.IsNullOrEmpty())
                 {
                     logger.Debug($"ffmpeg has not been configured");
                     PlayniteApi.Notifications.Add(new NotificationMessage("ffmpegExeNotConfigured", ResourceProvider.GetString("LOCExtra_Metadata_Loader_NotificationMessageFfmpegNotConfigured"), NotificationType.Error, () => OpenSettingsView()));
                     success = false;
                 }
-                else if (!FileSystem.FileExists(settings.Settings.FfmpegPath))
+                else if (!FileSystem.FileExists(ffmpegPath))
                 {
-                    logger.Debug($"ffmpeg executable not found in {settings.Settings.FfmpegPath}");
+                    logger.Debug($"ffmpeg executable not found in {ffmpegPath}");
                     PlayniteApi.Notifications.Add(new NotificationMessage("ffmpegExeNotFound", ResourceProvider.GetString("LOCExtra_Metadata_Loader_NotificationMessageFfmpegNotFound"), NotificationType.Error, () => OpenSettingsView()));
                     success = false;
                 }
 
                 // ffprobe
-                if (settings.Settings.FfprobePath.IsNullOrEmpty())
+                if (ffprobePath.IsNullOrEmpty())
                 {
                     logger.Debug($"ffprobe has not been configured");
                     PlayniteApi.Notifications.Add(new NotificationMessage("ffprobeExeNotConfigured", ResourceProvider.GetString("LOCExtra_Metadata_Loader_NotificationMessageFfprobeNotConfigured"), NotificationType.Error, () => OpenSettingsView()));
                     success = false;
                 }
-                else if (!FileSystem.FileExists(settings.Settings.FfprobePath))
+                else if (!FileSystem.FileExists(ffprobePath))
                 {
-                    logger.Debug($"ffprobe executable not found in {settings.Settings.FfprobePath}");
+                    logger.Debug($"ffprobe executable not found in {ffprobePath}");
                     PlayniteApi.Notifications.Add(new NotificationMessage("ffprobeExeNotFound", ResourceProvider.GetString("LOCExtra_Metadata_Loader_NotificationMessageFfprobeNotFound"), NotificationType.Error, () => OpenSettingsView()));
                     success = false;
                 }
@@ -931,15 +935,15 @@ namespace ExtraMetadataLoader
             if (validateYtdl)
             {
                 // youtube-dl
-                if (settings.Settings.YoutubeDlPath.IsNullOrEmpty())
+                if (youtubeDlPath.IsNullOrEmpty())
                 {
                     logger.Debug($"youtube-dl has not been configured");
                     PlayniteApi.Notifications.Add(new NotificationMessage("ytdlExeNotConfigured", ResourceProvider.GetString("LOCExtra_Metadata_Loader_NotificationMessageYoutubeDlNotConfigured"), NotificationType.Error, () => OpenSettingsView()));
                     success = false;
                 }
-                else if (!FileSystem.FileExists(settings.Settings.YoutubeDlPath))
+                else if (!FileSystem.FileExists(youtubeDlPath))
                 {
-                    logger.Debug($"youtube-dl executable not found in {settings.Settings.YoutubeDlPath}");
+                    logger.Debug($"youtube-dl executable not found in {youtubeDlPath}");
                     PlayniteApi.Notifications.Add(new NotificationMessage("ytdlExeNotFound", ResourceProvider.GetString("LOCExtra_Metadata_Loader_NotificationMessageYoutubeDlNotFound"), NotificationType.Error, () => OpenSettingsView()));
                     success = false;
                 }

--- a/source/Generic/ExtraMetadataLoader/ExtraMetadataLoaderSettingsView.xaml
+++ b/source/Generic/ExtraMetadataLoader/ExtraMetadataLoaderSettingsView.xaml
@@ -35,17 +35,17 @@
                         <DockPanel Margin="0,0,0,10">
                             <TextBlock Text="{DynamicResource LOCExtra_Metadata_Loader_SettingFfmpegPathLabel}" DockPanel.Dock="Left" VerticalAlignment="Center"/>
                             <Button Margin="10,0,0,0" DockPanel.Dock="Right" Content="{DynamicResource LOCExtra_Metadata_Loader_SettingBrowseLabel}" Command="{Binding BrowseSelectFfmpegCommand}" />
-                            <TextBox Margin="10,0,0,0" Text="{Binding Settings.FfmpegPath}" IsReadOnly="True" />
+                            <TextBox Margin="10,0,0,0" Text="{Binding Settings.FfmpegPath}" />
                         </DockPanel>
                         <DockPanel Margin="0,0,0,10">
                             <TextBlock Text="{DynamicResource LOCExtra_Metadata_Loader_SettingFfprobePathLabel}" DockPanel.Dock="Left" VerticalAlignment="Center"/>
                             <Button Margin="10,0,0,0" DockPanel.Dock="Right" Content="{DynamicResource LOCExtra_Metadata_Loader_SettingBrowseLabel}" Command="{Binding BrowseSelectFfprobeCommand}" />
-                            <TextBox Margin="10,0,0,0" Text="{Binding Settings.FfprobePath}" IsReadOnly="True" />
+                            <TextBox Margin="10,0,0,0" Text="{Binding Settings.FfprobePath}" />
                         </DockPanel>
                         <DockPanel Margin="0,0,0,10">
                             <TextBlock Text="{DynamicResource LOCExtra_Metadata_Loader_SettingYoutubeDlPathLabel}" DockPanel.Dock="Left" VerticalAlignment="Center"/>
                             <Button Margin="10,0,0,0" DockPanel.Dock="Right" Content="{DynamicResource LOCExtra_Metadata_Loader_SettingBrowseLabel}" Command="{Binding BrowseSelectYoutubeDlCommand}" />
-                            <TextBox Margin="10,0,0,0" Text="{Binding Settings.YoutubeDlPath}" IsReadOnly="True" />
+                            <TextBox Margin="10,0,0,0" Text="{Binding Settings.YoutubeDlPath}" />
                         </DockPanel>
                         <DockPanel Margin="0,0,0,10">
                             <TextBlock Text="{DynamicResource LOCExtra_Metadata_Loader_SettingYoutubeCookiesPathLabel}"

--- a/source/Generic/ExtraMetadataLoader/ExtraMetadataLoaderSettingsView.xaml
+++ b/source/Generic/ExtraMetadataLoader/ExtraMetadataLoaderSettingsView.xaml
@@ -63,7 +63,7 @@
                                     </Hyperlink>
                             </TextBlock>
 
-                            <TextBox Margin="10,0,0,0" Text="{Binding Settings.YoutubeCookiesPath}" IsReadOnly="True"
+                            <TextBox Margin="10,0,0,0" Text="{Binding Settings.YoutubeCookiesPath}"
                                      ToolTip="{DynamicResource LOCExtra_Metadata_Loader_SettingYoutubeCookiesPathTooltip}" />
                         </DockPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,20">

--- a/source/Generic/ExtraMetadataLoader/Helpers/ExtraMetadataHelper.cs
+++ b/source/Generic/ExtraMetadataLoader/Helpers/ExtraMetadataHelper.cs
@@ -162,5 +162,14 @@ namespace ExtraMetadataLoader.Helpers
             }
         }
 
+        public string ExpandVariables(string inputString)
+        {
+            return playniteApi.ExpandGameVariables(new Game(), inputString);
+        }
+
+        public string ExpandVariables(Game game, string inputString)
+        {
+            return playniteApi.ExpandGameVariables(game, inputString);
+        }
     }
 }


### PR DESCRIPTION
This fixes #344, there are no support to change the path in the GUI. I just change the path in the `config.json` directly. Also since the API uses the Game for some Variables and some of the methods don't supply it, I just `new Game()` instead in that case. So it will work with `{PlayniteDir}`, but might not always work with other Variables that require the Game object.

Did this for personal use, feel free to use it or modify it if required.

I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.
