### PR TITLE
[PlayState] Added playing & suspension reminders

### DIFF
--- a/source/Generic/PlayState/Localization/en_US.xaml
+++ b/source/Generic/PlayState/Localization/en_US.xaml
@@ -58,6 +58,10 @@ This mode can also be changed individually per game by using the extensions func
     <sys:String x:Key="LOCPlayState_Setting_SuspendModeLabel">Suspend mode:</sys:String>
     <sys:String x:Key="LOCPlayState_SettingNotificationShowSessionPlaytime">Display session playtime in notification message</sys:String>
     <sys:String x:Key="LOCPlayState_SettingNotificationShowTotalPlaytime">Display total playtime in notification message</sys:String>
+    <sys:String x:Key="LOCPlayState_SettingNotificationShowPlayingReminders">Display a notification when the current game has been played for more than x minutes</sys:String>
+    <sys:String x:Key="LOCPlayState_SettingNotificationShowSuspensionReminders">Display a notification if the current game has been suspended for more than x minutes</sys:String>
+    <sys:String x:Key="LOCPlayState_SettingNotificationPlayingReminderMinutes">Minutes for showing the playing reminder</sys:String>
+    <sys:String x:Key="LOCPlayState_SettingNotificationSuspensionReminderMinutes">Minutes for showing the suspension reminder</sys:String>
     <sys:String x:Key="LOCPlayState_SettingUseForegroundAutomaticSuspend">Automatically suspend games if they are not the active window</sys:String>
     <sys:String x:Key="LOCPlayState_SettingUseForegroundAutomaticSuspendNote" xml:space="preserve">This functionality will work differently depending on the suspend mode of the running game.
 

--- a/source/Generic/PlayState/Models/PlayStateData.cs
+++ b/source/Generic/PlayState/Models/PlayStateData.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Threading;
 
 namespace PlayState.Models
 {
@@ -20,6 +21,10 @@ namespace PlayState.Models
         public DateTime StartDate { get; } = DateTime.Now;
         private Stopwatch stopwatch = new Stopwatch();
         public Stopwatch Stopwatch { get => stopwatch; set => SetValue(ref stopwatch, value); }
+        private DispatcherTimer suspensionReminderTimer = new DispatcherTimer();
+        public DispatcherTimer SuspensionReminderTimer { get => suspensionReminderTimer; set => SetValue(ref suspensionReminderTimer, value); }
+        private DispatcherTimer playingReminderTimer = new DispatcherTimer();
+        public DispatcherTimer PlayingReminderTimer { get => playingReminderTimer; set => SetValue(ref playingReminderTimer, value); }
         public List<ProcessItem> GameProcesses { get; set; }
         public bool HasProcesses => GameProcesses?.HasItems() == true;
 
@@ -58,6 +63,14 @@ namespace PlayState.Models
             {
                 SetSuspendMode();
             }
+            if (e.PropertyName == nameof(settingsModel.Settings.NotificationPlayingReminderMinutes))
+            {
+                PlayingReminderTimer.Interval = TimeSpan.FromMinutes(settingsModel.Settings.NotificationPlayingReminderMinutes);
+            }
+            if (e.PropertyName == nameof(settingsModel.Settings.NotificationSuspensionReminderMinutes))
+            {
+                SuspensionReminderTimer.Interval = TimeSpan.FromMinutes(settingsModel.Settings.NotificationSuspensionReminderMinutes);
+            }
         }
 
         private void SetSuspendMode()
@@ -80,6 +93,8 @@ namespace PlayState.Models
         {
             Game.PropertyChanged -= Game_PropertyChanged;
             settingsModel.Settings.PropertyChanged -= Settings_PropertyChanged;
+            PlayingReminderTimer.Stop();
+            SuspensionReminderTimer.Stop();
         }
 
         public void SetProcesses(List<ProcessItem> gameProcesses)
@@ -93,6 +108,29 @@ namespace PlayState.Models
             {
                 GameProcesses = null;
             }
+        }
+
+        public void StartPlayingReminderTimer()
+        {
+            PlayingReminderTimer = new DispatcherTimer();
+            PlayingReminderTimer.Interval = TimeSpan.FromMinutes(settingsModel.Settings.NotificationPlayingReminderMinutes);
+            PlayingReminderTimer.Start();
+        }
+
+        public void StopPlayingReminderTimer()
+        {
+            PlayingReminderTimer.Stop();
+        }
+        public void StartSuspensionReminderTimer()
+        {
+            SuspensionReminderTimer = new DispatcherTimer();
+            SuspensionReminderTimer.Interval = TimeSpan.FromMinutes(settingsModel.Settings.NotificationSuspensionReminderMinutes);
+            SuspensionReminderTimer.Start();
+        }
+
+        public void StopSuspensionReminderTimer()
+        {
+            SuspensionReminderTimer.Stop();
         }
     }
 }

--- a/source/Generic/PlayState/PlayStateSettings.cs
+++ b/source/Generic/PlayState/PlayStateSettings.cs
@@ -59,6 +59,18 @@ namespace PlayState
         private bool notificationShowTotalPlaytime = true;
         public bool NotificationShowTotalPlaytime { get => notificationShowTotalPlaytime; set => SetValue(ref notificationShowTotalPlaytime, value); }
         public bool WindowsNotificationStyleFirstSetupDone = false;
+        [DontSerialize]
+        private bool notificationShowPlayingReminder = false;
+        public bool NotificationShowPlayingReminder { get => notificationShowPlayingReminder; set => SetValue(ref notificationShowPlayingReminder, value); }
+        [DontSerialize]
+        private bool notificationShowSuspensionReminder = false;
+        public bool NotificationShowSuspensionReminder { get => notificationShowSuspensionReminder; set => SetValue(ref notificationShowSuspensionReminder, value); }
+        [DontSerialize]
+        private int notificationPlayingReminderMinutes = 30;
+        public int NotificationPlayingReminderMinutes { get => notificationPlayingReminderMinutes; set => SetValue(ref notificationPlayingReminderMinutes, value); }
+        [DontSerialize]
+        private int notificationSuspensionReminderMinutes = 5;
+        public int NotificationSuspensionReminderMinutes { get => notificationSuspensionReminderMinutes; set => SetValue(ref notificationSuspensionReminderMinutes, value); }
 
         [DontSerialize]
         private bool showManagerSidebarItem = true;

--- a/source/Generic/PlayState/PlayStateSettingsView.xaml
+++ b/source/Generic/PlayState/PlayStateSettingsView.xaml
@@ -353,6 +353,28 @@
                         <CheckBox Content="{DynamicResource LOCPlayState_SettingNotificationShowTotalPlaytime}"
                               IsChecked="{Binding Settings.NotificationShowTotalPlaytime}"
                               Margin="0,10,0,0"/>
+                        <CheckBox Content="{DynamicResource LOCPlayState_SettingNotificationShowPlayingReminders}"
+                              IsChecked="{Binding Settings.NotificationShowPlayingReminder}"
+                              Margin="0,10,0,0"/>
+                        <DockPanel Margin="0,10,0,0">
+                            <TextBlock Text="{DynamicResource LOCPlayState_SettingNotificationPlayingReminderMinutes}"
+                                       DockPanel.Dock="Left"
+                                       VerticalAlignment="Center"/>
+                            <TextBox VerticalAlignment="Center" TextWrapping="WrapWithOverflow"
+                                     Margin="10,0,0,0"
+                                     Text="{Binding Settings.NotificationPlayingReminderMinutes}" />
+                        </DockPanel>
+                        <CheckBox Content="{DynamicResource LOCPlayState_SettingNotificationShowSuspensionReminders}"
+                              IsChecked="{Binding Settings.NotificationShowSuspensionReminder}"
+                              Margin="0,10,0,0"/>
+                        <DockPanel Margin="0,10,0,0">
+                            <TextBlock Text="{DynamicResource LOCPlayState_SettingNotificationSuspensionReminderMinutes}"
+                                       DockPanel.Dock="Left"
+                                       VerticalAlignment="Center"/>
+                            <TextBox VerticalAlignment="Center" TextWrapping="WrapWithOverflow"
+                                     Margin="10,0,0,0"
+                                     Text="{Binding Settings.NotificationSuspensionReminderMinutes}" />
+                        </DockPanel>
 
                     </StackPanel>
                 </StackPanel>

--- a/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
+++ b/source/Generic/PlayState/ViewModels/PlayStateManagerViewModel.cs
@@ -409,6 +409,22 @@ namespace PlayState.ViewModels
             }
         }
 
+        public void ShowPlayingReminderNotificationIfGameIsCurrentGame(PlayStateData gameData)
+        {
+            if (GetIsCurrentGameSame(gameData.Game) && settings.Settings.NotificationShowPlayingReminder)
+            {
+                ShowCurrentGameStatusNotification();
+            }
+        }
+
+        public void ShowSuspensionReminderNotificationIfGameIsCurrentGame(PlayStateData gameData)
+        {
+            if (GetIsCurrentGameSame(gameData.Game) && settings.Settings.NotificationShowSuspensionReminder)
+            {
+                ShowCurrentGameStatusNotification();
+            }
+        }
+
         public bool SwitchGameState(PlayStateData gameData, bool isGameStatusOverrided = true)
         {
             var handled = false;
@@ -444,6 +460,9 @@ namespace PlayState.ViewModels
                         gameData.IsSuspended = false;
                         notificationType = processesSuspended ? NotificationTypes.Resumed : NotificationTypes.PlaytimeResumed;
                         gameData.Stopwatch.Stop();
+                        gameData.StartPlayingReminderTimer();
+                        gameData.PlayingReminderTimer.Tick += (sender, e) => ShowPlayingReminderNotificationIfGameIsCurrentGame(gameData);
+                        gameData.StopSuspensionReminderTimer();
                         logger.Debug($"Game {gameData.Game.Name} resumed in mode {gameData.SuspendMode}");
                         if (isGameStatusOverrided)
                         {
@@ -456,6 +475,9 @@ namespace PlayState.ViewModels
                         gameData.IsSuspended = true;
                         notificationType = processesSuspended ? NotificationTypes.Suspended : NotificationTypes.PlaytimeSuspended;
                         gameData.Stopwatch.Start();
+                        gameData.StopPlayingReminderTimer();
+                        gameData.StartSuspensionReminderTimer();
+                        gameData.SuspensionReminderTimer.Tick += (sender, e) => ShowSuspensionReminderNotificationIfGameIsCurrentGame(gameData);
                         logger.Debug($"Game {gameData.Game.Name} suspended in mode {gameData.SuspendMode}");
                         if (isGameStatusOverrided)
                         {


### PR DESCRIPTION
I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.

-Supersede #309
-Closes #257

- Added a notification after x minutes of suspension of the game.
- Added a notification afer x minutes of playing the game.
- Added settings for enabling and disabling this and for the duration of each setting.

Opening as a draft since I would like to give it more testing, but the code should be complete.