### PR TITLE
Added MicroTrailer support

### DIFF
--- a/source/Generic/SplashScreen/Localization/en_US.xaml
+++ b/source/Generic/SplashScreen/Localization/en_US.xaml
@@ -14,10 +14,12 @@
     <sys:String x:Key="LOCSplashScreen_SettingCBexecuteInDesktopMode">Execute extension in Desktop Mode</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBviewImageSplashscreenDesktopMode">View splashscreen images in Desktop Mode</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBviewVideoDesktopMode">View intro videos in Desktop Mode</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingCBuseMicroTrailerDesktopMode">Use MicroTrailers in Desktop Mode</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBcloseSplashScreenDesktopMode">Automatically close splashscreen in Desktop Mode (Disabling hides desktop when game closes but can cause issues)</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBexecuteInFullscreenMode">Execute extension in Fullscreen Mode</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBviewImageSplashscreenFullscreenMode">View splashscreen images in Fullscreen Mode</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBviewVideoFullscreenMode">View intro videos in Fullscreen Mode</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingCBuseMicroTrailerFullscreenMode">Use MicroTrailers in Fullscreen Mode</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBcloseSplashScreenFullscreenMode">Automatically close splashscreen in Fullscreen Mode (Disabling hides desktop when game closes but can cause issues)</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBshowLogoInSplashscreen">Add game logo in splashscreen image if available</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBuseIconAsLogo">Use game icon from Metadata as logo</sys:String>

--- a/source/Generic/SplashScreen/Localization/en_US.xaml
+++ b/source/Generic/SplashScreen/Localization/en_US.xaml
@@ -14,12 +14,11 @@
     <sys:String x:Key="LOCSplashScreen_SettingCBexecuteInDesktopMode">Execute extension in Desktop Mode</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBviewImageSplashscreenDesktopMode">View splashscreen images in Desktop Mode</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBviewVideoDesktopMode">View intro videos in Desktop Mode</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingCBuseMicroTrailerDesktopMode">Use MicroTrailers in Desktop Mode</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingCBuseMicroTrailer">Use MicroTrailers</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBcloseSplashScreenDesktopMode">Automatically close splashscreen in Desktop Mode (Disabling hides desktop when game closes but can cause issues)</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBexecuteInFullscreenMode">Execute extension in Fullscreen Mode</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBviewImageSplashscreenFullscreenMode">View splashscreen images in Fullscreen Mode</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBviewVideoFullscreenMode">View intro videos in Fullscreen Mode</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingCBuseMicroTrailerFullscreenMode">Use MicroTrailers in Fullscreen Mode</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBcloseSplashScreenFullscreenMode">Automatically close splashscreen in Fullscreen Mode (Disabling hides desktop when game closes but can cause issues)</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBshowLogoInSplashscreen">Add game logo in splashscreen image if available</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingCBuseIconAsLogo">Use game icon from Metadata as logo</sys:String>

--- a/source/Generic/SplashScreen/SplashScreen.cs
+++ b/source/Generic/SplashScreen/SplashScreen.cs
@@ -32,6 +32,8 @@ namespace SplashScreen
         private readonly DispatcherTimer timerWindowRemoveTopMost;
         private const string featureNameSplashScreenDisable = "[Splash Screen] Disable";
         private const string featureNameSkipSplashImage = "[Splash Screen] Skip splash image";
+        private const string videoIntroName = "VideoIntro.mp4";
+        private const string microVideoName = "VideoMicrotrailer.mp4";
 
         private SplashScreenSettingsViewModel settings { get; set; }
 
@@ -331,9 +333,6 @@ namespace SplashScreen
 
         private string GetSplashVideoPath(Game game)
         {
-            const string videoIntroName = "VideoIntro.mp4";
-            const string microVideoName = "VideoMicrotrailer.mp4";
-
             var baseVideoPathTemplate = Path.Combine(PlayniteApi.Paths.ConfigurationPath, "ExtraMetadata", "{0}", "{1}");
             
             var baseSplashVideo = string.Format(baseVideoPathTemplate, "games", game.Id.ToString());
@@ -375,9 +374,7 @@ namespace SplashScreen
                 }
             }
 
-            var mode = isDesktop
-                ? "Desktop"
-                : "Fullscreen";
+            var mode = isDesktop ? "Desktop" : "Fullscreen";
             
             splashVideo = string.Format(videoPathTemplate, "playnite", mode);
 
@@ -398,8 +395,8 @@ namespace SplashScreen
             return videoPath;
         }
 
-        private bool ShouldUseMicroTrailer(bool isDekstop) 
-            => isDekstop
+        private bool ShouldUseMicroTrailer(bool isDesktop) 
+            => isDesktop
                 ? settings.Settings.UseMicroTrailersInDesktopMode
                 : settings.Settings.UseMicroTrailersInFullscreenMode;
 

--- a/source/Generic/SplashScreen/SplashScreenSettings.cs
+++ b/source/Generic/SplashScreen/SplashScreenSettings.cs
@@ -17,10 +17,12 @@ namespace SplashScreen
         public bool ViewImageSplashscreenDesktopMode { get; set; } = true;
         public bool ViewVideoDesktopMode { get; set; } = true;
         public bool CloseSplashScreenDesktopMode { get; set; } = true;
+        public bool UseMicroTrailersInDesktopMode { get; set; } = false;
         public bool ExecuteInFullscreenMode { get; set; } = true;
         public bool ViewImageSplashscreenFullscreenMode { get; set; } = true;
         public bool ViewVideoFullscreenMode { get; set; } = true;
         public bool CloseSplashScreenFullscreenMode { get; set; } = true;
+        public bool UseMicroTrailersInFullscreenMode { get; set; } = false;
         public bool ShowLogoInSplashscreen { get; set; } = true;
         public bool UseIconAsLogo { get; set; } = false;
         public HorizontalAlignment LogoHorizontalAlignment { get; set; } = HorizontalAlignment.Left;

--- a/source/Generic/SplashScreen/SplashScreenSettingsView.xaml
+++ b/source/Generic/SplashScreen/SplashScreenSettingsView.xaml
@@ -22,16 +22,16 @@
                 <CheckBox Name="ExecuteDesktopMode" IsChecked="{Binding Settings.ExecuteInDesktopMode}" Content="{DynamicResource LOCSplashScreen_SettingCBexecuteInDesktopMode}" Margin="0,10,0,0" />
                 <StackPanel Margin="40,0,0,0" IsEnabled="{Binding ElementName=ExecuteDesktopMode, Path=IsChecked}">
                     <CheckBox IsChecked="{Binding Settings.ViewImageSplashscreenDesktopMode}" Content="{DynamicResource LOCSplashScreen_SettingCBviewImageSplashscreenDesktopMode}" Margin="0,10,0,0" />
-                    <CheckBox IsChecked="{Binding Settings.ViewVideoDesktopMode}" Content="{DynamicResource LOCSplashScreen_SettingCBviewVideoDesktopMode}" Margin="0,10,0,0" />
-                    <CheckBox IsChecked="{Binding Settings.UseMicroTrailersInDesktopMode}" Content="{DynamicResource LOCSplashScreen_SettingCBuseMicroTrailerDesktopMode}" Margin="0,10,0,0" />
+                    <CheckBox Name="ViewVideoDesktopMode" IsChecked="{Binding Settings.ViewVideoDesktopMode}" Content="{DynamicResource LOCSplashScreen_SettingCBviewVideoDesktopMode}" Margin="0,10,0,0" />
+                    <CheckBox IsChecked="{Binding Settings.UseMicroTrailersInDesktopMode}" IsEnabled="{Binding ElementName=ViewVideoDesktopMode, Path=IsChecked}" Content="{DynamicResource LOCSplashScreen_SettingCBuseMicroTrailer}" Margin="20,10,0,0" />
                     <CheckBox IsChecked="{Binding Settings.CloseSplashScreenDesktopMode}" Content="{DynamicResource LOCSplashScreen_SettingCBcloseSplashScreenDesktopMode}" Margin="0,10,0,0" />
                 </StackPanel>
 
                 <CheckBox Name="ExecuteFullscreenMode" IsChecked="{Binding Settings.ExecuteInFullscreenMode}" Content="{DynamicResource LOCSplashScreen_SettingCBexecuteInFullscreenMode}" Margin="0,20,0,0"/>
                 <StackPanel Margin="40,0,0,0" IsEnabled="{Binding ElementName=ExecuteFullscreenMode, Path=IsChecked}">
                     <CheckBox IsChecked="{Binding Settings.ViewImageSplashscreenFullscreenMode}" Content="{DynamicResource LOCSplashScreen_SettingCBviewImageSplashscreenFullscreenMode}" Margin="0,10,0,0" />
-                    <CheckBox IsChecked="{Binding Settings.ViewVideoFullscreenMode}" Content="{DynamicResource LOCSplashScreen_SettingCBviewVideoFullscreenMode}" Margin="0,10,0,0" />
-                    <CheckBox IsChecked="{Binding Settings.UseMicroTrailersInFullscreenMode}" Content="{DynamicResource LOCSplashScreen_SettingCBuseMicroTrailerFullscreenMode}" Margin="0,10,0,0" />
+                    <CheckBox Name="ViewVideoFullscreenMode" IsChecked="{Binding Settings.ViewVideoFullscreenMode}" Content="{DynamicResource LOCSplashScreen_SettingCBviewVideoFullscreenMode}" Margin="0,10,0,0" />
+                    <CheckBox IsChecked="{Binding Settings.UseMicroTrailersInFullscreenMode}" IsEnabled="{Binding ElementName=ViewVideoFullscreenMode, Path=IsChecked}" Content="{DynamicResource LOCSplashScreen_SettingCBuseMicroTrailer}" Margin="20,10,0,0" />
                     <CheckBox IsChecked="{Binding Settings.CloseSplashScreenFullscreenMode}" Content="{DynamicResource LOCSplashScreen_SettingCBcloseSplashScreenFullscreenMode}" Margin="0,10,0,0" />
                 </StackPanel>
                 <CheckBox Content="{DynamicResource LOCSplashScreen_SettingCBuseBlackSplashscreen}"

--- a/source/Generic/SplashScreen/SplashScreenSettingsView.xaml
+++ b/source/Generic/SplashScreen/SplashScreenSettingsView.xaml
@@ -23,6 +23,7 @@
                 <StackPanel Margin="40,0,0,0" IsEnabled="{Binding ElementName=ExecuteDesktopMode, Path=IsChecked}">
                     <CheckBox IsChecked="{Binding Settings.ViewImageSplashscreenDesktopMode}" Content="{DynamicResource LOCSplashScreen_SettingCBviewImageSplashscreenDesktopMode}" Margin="0,10,0,0" />
                     <CheckBox IsChecked="{Binding Settings.ViewVideoDesktopMode}" Content="{DynamicResource LOCSplashScreen_SettingCBviewVideoDesktopMode}" Margin="0,10,0,0" />
+                    <CheckBox IsChecked="{Binding Settings.UseMicroTrailersInDesktopMode}" Content="{DynamicResource LOCSplashScreen_SettingCBuseMicroTrailerDesktopMode}" Margin="0,10,0,0" />
                     <CheckBox IsChecked="{Binding Settings.CloseSplashScreenDesktopMode}" Content="{DynamicResource LOCSplashScreen_SettingCBcloseSplashScreenDesktopMode}" Margin="0,10,0,0" />
                 </StackPanel>
 
@@ -30,6 +31,7 @@
                 <StackPanel Margin="40,0,0,0" IsEnabled="{Binding ElementName=ExecuteFullscreenMode, Path=IsChecked}">
                     <CheckBox IsChecked="{Binding Settings.ViewImageSplashscreenFullscreenMode}" Content="{DynamicResource LOCSplashScreen_SettingCBviewImageSplashscreenFullscreenMode}" Margin="0,10,0,0" />
                     <CheckBox IsChecked="{Binding Settings.ViewVideoFullscreenMode}" Content="{DynamicResource LOCSplashScreen_SettingCBviewVideoFullscreenMode}" Margin="0,10,0,0" />
+                    <CheckBox IsChecked="{Binding Settings.UseMicroTrailersInFullscreenMode}" Content="{DynamicResource LOCSplashScreen_SettingCBuseMicroTrailerFullscreenMode}" Margin="0,10,0,0" />
                     <CheckBox IsChecked="{Binding Settings.CloseSplashScreenFullscreenMode}" Content="{DynamicResource LOCSplashScreen_SettingCBcloseSplashScreenFullscreenMode}" Margin="0,10,0,0" />
                 </StackPanel>
                 <CheckBox Content="{DynamicResource LOCSplashScreen_SettingCBuseBlackSplashscreen}"


### PR DESCRIPTION
Will only use micro trailer if settings allow it, the file exists, & the user has not manually specified a file.
Also, some minor refactors in the relevant code because why not.

Tested each of the following options for a total of 8 test cases:
- Playnite Mode state (Desktop or Fullscreen)
- UseMicroTrailerFullscreenMode
- UseMicroTrailerDesktopMode

Also tested:
- Intro video & Micro trailer files do not exist
- Intro video & Micro trailer files exist
