### PR TITLE
[PlayNotes] Use font family and size from Playnite settings

### DIFF
--- a/source/Generic/PlayNotes/PlayNotesSettings.cs
+++ b/source/Generic/PlayNotes/PlayNotesSettings.cs
@@ -85,6 +85,29 @@ namespace PlayNotes
                 imageStyle.Setters.Add(new Setter(Image.MaxWidthProperty, maxWidthBinding));
             }
 
+            var baseStyleName = plugin.PlayniteApi.ApplicationInfo.Mode == ApplicationMode.Desktop ? "BaseTextBlockStyle" : "TextBlockBaseStyle";
+            if (ResourceProvider.GetResource(baseStyleName) is Style baseStyle &&
+                baseStyle.TargetType == typeof(TextBlock))
+            {
+                foreach(Setter s in baseStyle.Setters.Cast<Setter>())
+                {
+                    switch (s.Property.Name)
+                    {
+                        case "FontSize":
+                            markdownStyle.Setters.Add(new Setter(FlowDocument.FontSizeProperty, s.Value));
+                            break;
+
+                        case "FontFamily":
+                            markdownStyle.Setters.Add(new Setter(FlowDocument.FontFamilyProperty, s.Value));
+                            break;
+
+                        case "Foreground":
+                            markdownStyle.Setters.Add(new Setter(FlowDocument.ForegroundProperty, s.Value));
+                            break;
+                    }
+                }
+            }
+
             settings.MarkdownStyle = markdownStyle;
         }
 


### PR DESCRIPTION
### The problem

Notes from PlayNotes plugin uses Calibri font instead of Playnite's font:
![](https://github.com/darklinkpower/PlayniteExtensionsCollection/assets/2903496/9e7e71d6-543a-40f2-b800-b0477f075790)
> Theme: Mythic, UI font: IBM Plex Sans, but font in screenshot is certainly wrong.

### The solution

The thing is, font settings are taken from MdXaml's Markdown style. Initially I've found the way to fix it from XAML (ref: https://github.com/whistyun/MdXaml/issues/14), but since it uses binding, the fix was need from C# side.

After adding the first line the font looked good, but the size was wrong:

![](https://github.com/darklinkpower/PlayniteExtensionsCollection/assets/2903496/4ac0077f-a5f5-4184-a12e-bb8efbce6137)
> Theme: Mythic, UI font: IBM Plex Sans. Font is same, but it's even bigger than tab title.

This has been solved by adding the second line, where FontSize property is taken from settings:
![](https://github.com/darklinkpower/PlayniteExtensionsCollection/assets/2903496/2ef2cc2e-a75a-4266-8d02-ef6a7aa4065c)
> Theme: Mythic, UI font: IBM Plex Sans. Everything looks good now.

### Additional possible fixes

It's possible that font color could be also adjusted to themes. Here's an example on Mythic theme:

![](https://github.com/darklinkpower/PlayniteExtensionsCollection/assets/2903496/e2180360-4b27-4d33-9701-b29ff1f01d83)

To do this, I've added a follwing line after proposed ones:
```c#
markdownStyle.Setters.Add(new Setter(FlowDocument.ForegroundProperty, ResourceProvider.GetResource("TextBrushDark")));
```

However, I'm not sure that using `TextBrushDark` color will suite any theme, so I haven't introduced it in this PR.

---
I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.
