### PR TITLE
Fix for tag not being added for games removed from Game Pass if those games have been played.

### DIFF
--- a/source/Generic/GamePassCatalogBrowser/Services/GamePassCatalogBrowserService.cs
+++ b/source/Generic/GamePassCatalogBrowser/Services/GamePassCatalogBrowserService.cs
@@ -430,7 +430,7 @@ namespace GamePassCatalogBrowser.Services
                             NotificationType.Info));
                     }
                 }
-                else if (addExpiredTagToGames == true)
+                if (addExpiredTagToGames == true)
                 {
                     xboxLibraryHelper.AddExpiredTag(game);
                 }


### PR DESCRIPTION
Games that have been played on Game Pass are not removed from the library as they would only be re-imported later (see XboxLibraryHelper.cs). However, those games should be still be marked as expired in the library. Currently, if the extension is set to remove expired games, then the option to tag expired games is never invoked. This commit is meant to fix that.
Fixes https://github.com/darklinkpower/PlayniteExtensionsCollection/issues/25 and https://github.com/darklinkpower/PlayniteExtensionsCollection/issues/351

I have verified that:
- [ ] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.
