### PR TITLE
VNDBNexus: Fix crash when Character Sex is "n" (meaning “sexless”)

### DIFF
--- a/source/Metadata/VNDB/VndbApiDomain/Aggregates/Character/CharacterConstants.cs
+++ b/source/Metadata/VNDB/VndbApiDomain/Aggregates/Character/CharacterConstants.cs
@@ -191,6 +191,11 @@ namespace VndbApiDomain.CharacterAggregate
             /// Both.
             /// </summary>
             public const string Both = "b";
+
+            /// <summary>
+            /// Sexless.
+            /// </summary>
+            public const string Sexless = "n";
         }
 
         public static class VisualNovelRoles

--- a/source/Metadata/VNDB/VndbApiDomain/Aggregates/Character/CharacterSexEnum.cs
+++ b/source/Metadata/VNDB/VndbApiDomain/Aggregates/Character/CharacterSexEnum.cs
@@ -25,7 +25,13 @@ namespace VndbApiDomain.CharacterAggregate
         /// Both.
         /// </summary>
         [StringRepresentation(CharacterConstants.Sex.Both)]
-        Both
+        Both,
+
+        /// <summary>
+        /// Sexless.
+        /// </summary>
+        [StringRepresentation(CharacterConstants.Sex.Sexless)]
+        Sexless
     }
 
 }

--- a/source/Metadata/VNDB/VndbApiInfrastructure/Aggregates/Character/CharacterConstants.cs
+++ b/source/Metadata/VNDB/VndbApiInfrastructure/Aggregates/Character/CharacterConstants.cs
@@ -169,7 +169,7 @@ namespace VndbApiInfrastructure.CharacterAggregate
             public const string Birthday = "birthday";
 
             /// <summary>
-            /// Possibly null, otherwise an array of two strings: the character’s apparent (non-spoiler) sex and the character’s real (spoiler) sex. Possible values are null, "m", "f" or "b" (meaning “both”).
+            /// Possibly null, otherwise an array of two strings: the character’s apparent (non-spoiler) sex and the character’s real (spoiler) sex. Possible values are null, "m", "f", "b" (meaning “both”) or "n" (sexless).
             /// </summary>
             public const string Sex = "sex";
 


### PR DESCRIPTION
I have verified that:
- [X] These changes work, by building the extension and testing.
- [X] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [X] Pull request is targeting `master` branch.
