### PR TITLE
[SpecialK Helper] Added a toggle to keep SpecialK services running

### DIFF
--- a/source/Generic/SpecialKHelper/Core/Application/SpecialKHelper.cs
+++ b/source/Generic/SpecialKHelper/Core/Application/SpecialKHelper.cs
@@ -220,7 +220,10 @@ namespace SpecialKHelper
                 _steamHelper.RemoveBigPictureModeEnvVariable();
             }
 
-            StopAllSpecialKServices();
+            if (!settings.Settings.KeepServicesRunning)
+            {
+                StopAllSpecialKServices();
+            }
         }
 
         private void StopAllSpecialKServices()

--- a/source/Generic/SpecialKHelper/Core/Application/SpecialKHelperSettings.cs
+++ b/source/Generic/SpecialKHelper/Core/Application/SpecialKHelperSettings.cs
@@ -48,6 +48,8 @@ namespace SpecialKHelper
         public bool StopIfEasyAntiCheat { get => stopIfEasyAntiCheat; set => SetValue(ref stopIfEasyAntiCheat, value); }
         private string customSpecialKPath = string.Empty;
         public string CustomSpecialKPath { get => customSpecialKPath; set => SetValue(ref customSpecialKPath, value); }
+        private bool _keepServicesRunning = true;
+        public bool KeepServicesRunning { get => _keepServicesRunning; set => SetValue(ref _keepServicesRunning, value); }
     }
 
     public class SpecialKHelperSettingsViewModel : ObservableObject, ISettings

--- a/source/Generic/SpecialKHelper/Core/Localization/en_US.xaml
+++ b/source/Generic/SpecialKHelper/Core/Localization/en_US.xaml
@@ -31,6 +31,7 @@ Selective Mode: Special K services are started only for games that have the incl
     <sys:String x:Key="LOCSpecial_K_Helper_SettingStopIfVac">Stop start of services if game has "Valve Anti-Cheat Enabled" feature</sys:String>
     <sys:String x:Key="LOCSpecial_K_Helper_SettingStopIfEac">Stop start of services if it is detected that the game uses EasyAntiCheat</sys:String>
     <sys:String x:Key="LOCSpecial_K_Helper_SettingRunOnlyPcGames">Only start Special K services when starting PC games</sys:String>
+    <sys:String x:Key="LOCSpecial_K_Helper_SettingKeepServicesRunning">Keep services running after game is closed</sys:String>
 
     <sys:String x:Key="LOCSpecial_K_Helper_SettingNewProfileSettingsLabel">Default settings for new profiles created by Special K</sys:String>
     <sys:String x:Key="LOCSpecial_K_Helper_SettingNewProfileEnableSteamOverlay">Enable Steam overlay</sys:String>

--- a/source/Generic/SpecialKHelper/Core/Presentation/SpecialKHelperSettingsView.xaml
+++ b/source/Generic/SpecialKHelper/Core/Presentation/SpecialKHelperSettingsView.xaml
@@ -46,6 +46,9 @@
                 
                 <Separator Margin="0,10,0,0"/>
                 
+                <CheckBox Margin="0,10,0,0" Content="{DynamicResource LOCSpecial_K_Helper_SettingKeepServicesRunning}"
+                          IsChecked="{Binding Settings.KeepServicesRunning}" />
+                
                 <CheckBox Margin="0,10,0,0" Content="{DynamicResource LOCSpecial_K_Helper_SettingStopIfVac}"
                       IsChecked="{Binding Settings.StopExecutionIfVac}" />
 


### PR DESCRIPTION
This adds a toggle to keep SpecialK services running after the game closes.
Closes feature request #689.

I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.
