### PR TITLE
Feat/splashscreen custom loading indicator and safe area padding

### DIFF
--- a/source/Generic/SplashScreen/Helpers/SpinnerGeometryBuilder.cs
+++ b/source/Generic/SplashScreen/Helpers/SpinnerGeometryBuilder.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace SplashScreen.Helpers
+{
+    internal static class SpinnerGeometryBuilder
+    {
+        internal static Geometry BuildDashGeometry(double spinnerSize, double thickness, double dashLengthPx, int dashCount, bool roundedDashes)
+        {
+            var clampedDashCount = Math.Max(2, Math.Min(360, dashCount));
+            var innerSize = Math.Max(2.0, spinnerSize - thickness);
+            var radius = innerSize / 2.0;
+            var circumference = 2.0 * Math.PI * radius;
+            var slotPx = circumference / clampedDashCount;
+            var slotAngle = (2.0 * Math.PI) / clampedDashCount;
+
+            var centerlineDashPx = Math.Max(0.25, dashLengthPx);
+            if (roundedDashes)
+            {
+                centerlineDashPx = Math.Max(0.25, centerlineDashPx - thickness);
+            }
+
+            if (centerlineDashPx >= slotPx)
+            {
+                centerlineDashPx = slotPx * 0.9;
+            }
+
+            var dashAngle = centerlineDashPx / radius;
+            var maxDashAngle = slotAngle * 0.9;
+            if (dashAngle > maxDashAngle)
+            {
+                dashAngle = maxDashAngle;
+            }
+
+            var center = spinnerSize / 2.0;
+            var geometry = new PathGeometry();
+
+            for (var i = 0; i < clampedDashCount; i++)
+            {
+                var centerAngle = (-Math.PI / 2.0) + (i * slotAngle);
+                var startAngle = centerAngle - (dashAngle / 2.0);
+                var endAngle = centerAngle + (dashAngle / 2.0);
+
+                var startPoint = PointOnCircle(center, radius, startAngle);
+                var endPoint = PointOnCircle(center, radius, endAngle);
+
+                var figure = new PathFigure
+                {
+                    StartPoint = startPoint,
+                    IsClosed = false,
+                    IsFilled = false
+                };
+
+                figure.Segments.Add(new ArcSegment
+                {
+                    Point = endPoint,
+                    Size = new Size(radius, radius),
+                    IsLargeArc = false,
+                    SweepDirection = SweepDirection.Clockwise
+                });
+
+                geometry.Figures.Add(figure);
+            }
+
+            return geometry;
+        }
+
+        private static Point PointOnCircle(double center, double radius, double angle)
+        {
+            return new Point(
+                center + (radius * Math.Cos(angle)),
+                center + (radius * Math.Sin(angle))
+            );
+        }
+    }
+}

--- a/source/Generic/SplashScreen/Helpers/SpinnerGeometryBuilder.cs
+++ b/source/Generic/SplashScreen/Helpers/SpinnerGeometryBuilder.cs
@@ -6,32 +6,14 @@ namespace SplashScreen.Helpers
 {
     internal static class SpinnerGeometryBuilder
     {
-        internal static Geometry BuildDashGeometry(double spinnerSize, double thickness, double dashLengthPx, int dashCount, bool roundedDashes)
+        internal static Geometry BuildDashGeometry(double spinnerSize, double thickness, double dashLengthPercent, int dashCount, bool roundedDashes)
         {
-            var clampedDashCount = Math.Max(2, Math.Min(360, dashCount));
+            var clampedDashCount = Math.Max(1, Math.Min(360, dashCount));
             var innerSize = Math.Max(2.0, spinnerSize - thickness);
             var radius = innerSize / 2.0;
-            var circumference = 2.0 * Math.PI * radius;
-            var slotPx = circumference / clampedDashCount;
             var slotAngle = (2.0 * Math.PI) / clampedDashCount;
-
-            var centerlineDashPx = Math.Max(0.25, dashLengthPx);
-            if (roundedDashes)
-            {
-                centerlineDashPx = Math.Max(0.25, centerlineDashPx - thickness);
-            }
-
-            if (centerlineDashPx >= slotPx)
-            {
-                centerlineDashPx = slotPx * 0.9;
-            }
-
-            var dashAngle = centerlineDashPx / radius;
-            var maxDashAngle = slotAngle * 0.9;
-            if (dashAngle > maxDashAngle)
-            {
-                dashAngle = maxDashAngle;
-            }
+            var clampedDashLengthPercent = Math.Max(1.0, Math.Min(100.0, dashLengthPercent));
+            var dashAngle = slotAngle * (clampedDashLengthPercent / 100.0);
 
             var center = spinnerSize / 2.0;
             var geometry = new PathGeometry();
@@ -41,29 +23,58 @@ namespace SplashScreen.Helpers
                 var centerAngle = (-Math.PI / 2.0) + (i * slotAngle);
                 var startAngle = centerAngle - (dashAngle / 2.0);
                 var endAngle = centerAngle + (dashAngle / 2.0);
+                AddDashFigure(geometry, center, radius, startAngle, endAngle, dashAngle);
+            }
 
-                var startPoint = PointOnCircle(center, radius, startAngle);
-                var endPoint = PointOnCircle(center, radius, endAngle);
+            return geometry;
+        }
 
-                var figure = new PathFigure
-                {
-                    StartPoint = startPoint,
-                    IsClosed = false,
-                    IsFilled = false
-                };
+        private static void AddDashFigure(PathGeometry geometry, double center, double radius, double startAngle, double endAngle, double dashAngle)
+        {
+            var normalizedDashAngle = Math.Max(0.0, dashAngle);
+            var fullCircleThreshold = (2.0 * Math.PI) - 0.0001;
+            var startPoint = PointOnCircle(center, radius, startAngle);
+
+            var figure = new PathFigure
+            {
+                StartPoint = startPoint,
+                IsClosed = false,
+                IsFilled = false
+            };
+
+            if (normalizedDashAngle >= fullCircleThreshold)
+            {
+                var middlePoint = PointOnCircle(center, radius, startAngle + Math.PI);
 
                 figure.Segments.Add(new ArcSegment
                 {
-                    Point = endPoint,
+                    Point = middlePoint,
                     Size = new Size(radius, radius),
                     IsLargeArc = false,
                     SweepDirection = SweepDirection.Clockwise
                 });
 
-                geometry.Figures.Add(figure);
+                figure.Segments.Add(new ArcSegment
+                {
+                    Point = startPoint,
+                    Size = new Size(radius, radius),
+                    IsLargeArc = false,
+                    SweepDirection = SweepDirection.Clockwise
+                });
+            }
+            else
+            {
+                var endPoint = PointOnCircle(center, radius, endAngle);
+                figure.Segments.Add(new ArcSegment
+                {
+                    Point = endPoint,
+                    Size = new Size(radius, radius),
+                    IsLargeArc = normalizedDashAngle > Math.PI,
+                    SweepDirection = SweepDirection.Clockwise
+                });
             }
 
-            return geometry;
+            geometry.Figures.Add(figure);
         }
 
         private static Point PointOnCircle(double center, double radius, double angle)

--- a/source/Generic/SplashScreen/Helpers/SpinnerRenderHelper.cs
+++ b/source/Generic/SplashScreen/Helpers/SpinnerRenderHelper.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Windows.Media;
+using System.Windows.Shapes;
+
+namespace SplashScreen.Helpers
+{
+    internal static class SpinnerRenderHelper
+    {
+        internal static double ClampThickness(double thickness)
+        {
+            return Math.Max(0.5, thickness);
+        }
+
+        internal static double ClampDashLengthPercent(double dashLengthPercent)
+        {
+            return Math.Max(1.0, Math.Min(100.0, dashLengthPercent));
+        }
+
+        internal static int ClampDashCount(int dashCount)
+        {
+            return Math.Max(1, Math.Min(360, dashCount));
+        }
+
+        internal static double ClampSpinnerSize(double spinnerSize)
+        {
+            return Math.Max(4.0, spinnerSize);
+        }
+
+        internal static double CalculateRotationDurationSeconds(double baseSeconds, bool autoSpeed, double spinnerSize)
+        {
+            var normalizedBaseSeconds = baseSeconds;
+            if (normalizedBaseSeconds <= 0)
+            {
+                normalizedBaseSeconds = 3.0;
+            }
+
+            var durationSeconds = normalizedBaseSeconds;
+            if (autoSpeed)
+            {
+                var normalizedSize = spinnerSize / 50.0;
+                if (normalizedSize < 0.4)
+                {
+                    normalizedSize = 0.4;
+                }
+
+                durationSeconds = normalizedBaseSeconds * normalizedSize;
+            }
+
+            if (durationSeconds < 0.25)
+            {
+                durationSeconds = 0.25;
+            }
+
+            if (durationSeconds > 20.0)
+            {
+                durationSeconds = 20.0;
+            }
+
+            return durationSeconds;
+        }
+
+        internal static void ApplySpinnerAppearance(Path spinnerPath, double spinnerSize, double thickness, double dashLengthPercent, int dashCount, bool roundedDashes)
+        {
+            if (spinnerPath == null)
+            {
+                return;
+            }
+
+            var normalizedThickness = ClampThickness(thickness);
+            var normalizedDashLengthPercent = ClampDashLengthPercent(dashLengthPercent);
+            var normalizedDashCount = ClampDashCount(dashCount);
+            var normalizedSpinnerSize = ClampSpinnerSize(spinnerSize);
+
+            spinnerPath.StrokeThickness = normalizedThickness;
+            spinnerPath.StrokeDashArray = null;
+            spinnerPath.StrokeDashOffset = 0;
+            spinnerPath.StrokeDashCap = PenLineCap.Flat;
+            spinnerPath.StrokeStartLineCap = roundedDashes ? PenLineCap.Round : PenLineCap.Flat;
+            spinnerPath.StrokeEndLineCap = roundedDashes ? PenLineCap.Round : PenLineCap.Flat;
+            spinnerPath.Data = SpinnerGeometryBuilder.BuildDashGeometry(normalizedSpinnerSize, normalizedThickness, normalizedDashLengthPercent, normalizedDashCount, roundedDashes);
+        }
+    }
+}

--- a/source/Generic/SplashScreen/Helpers/SplashSettingsSyncHelper.cs
+++ b/source/Generic/SplashScreen/Helpers/SplashSettingsSyncHelper.cs
@@ -1,0 +1,25 @@
+using SplashScreen.Models;
+
+namespace SplashScreen.Helpers
+{
+    internal static class SplashSettingsSyncHelper
+    {
+        internal static void ApplyGlobalIndicatorSettings(GeneralSplashSettings target, GeneralSplashSettings global)
+        {
+            if (target == null || global == null)
+            {
+                return;
+            }
+
+            target.EnableLoadingSpinner = global.EnableLoadingSpinner;
+            target.LoadingSpinnerSize = global.LoadingSpinnerSize;
+            target.LoadingSpinnerOpacity = global.LoadingSpinnerOpacity;
+            target.LoadingSpinnerThickness = global.LoadingSpinnerThickness;
+            target.LoadingSpinnerDashLength = global.LoadingSpinnerDashLength;
+            target.LoadingSpinnerDashCount = global.LoadingSpinnerDashCount;
+            target.LoadingSpinnerRoundedDashes = global.LoadingSpinnerRoundedDashes;
+            target.LoadingSpinnerRotationSeconds = global.LoadingSpinnerRotationSeconds;
+            target.EnableLoadingSpinnerAutoSpeed = global.EnableLoadingSpinnerAutoSpeed;
+        }
+    }
+}

--- a/source/Generic/SplashScreen/Localization/af_ZA.xaml
+++ b/source/Generic/SplashScreen/Localization/af_ZA.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Wys laaispinner</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Spinnergrootte (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Spinner-deursigtigheid:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Spinner-spoed (sekondes per omwenteling):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Voorskou:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Voorskou-agtergrond:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Dikte van laaispinner (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Aantal strepies van laaispinner:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lengte van spinnerstrepie (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Gebruik afgeronde strepie-eindes</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Pas spinner-spoed outomaties aan volgens spinnergrootte</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Veilige area-opvulling (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Ondeursigtigheid van agtergrondbeeld:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/af_ZA.xaml
+++ b/source/Generic/SplashScreen/Localization/af_ZA.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Voorskou-agtergrond:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Dikte van laaispinner (pixels):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Aantal strepies van laaispinner:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lengte van spinnerstrepie (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lengte van spinnerstrepie (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Gebruik afgeronde strepie-eindes</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Pas spinner-spoed outomaties aan volgens spinnergrootte</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/ar_SA.xaml
+++ b/source/Generic/SplashScreen/Localization/ar_SA.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">خلفية المعاينة:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">سُمك المؤشر الدوار (بالبكسل):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">عدد شرطات المؤشر الدوار:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">طول شرطة المؤشر الدوار (بالبكسل):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">طول شرطة المؤشر الدوار (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">استخدام نهايات مستديرة للشرطات</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">ضبط سرعة المؤشر الدوار تلقائيا حسب الحجم</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/ar_SA.xaml
+++ b/source/Generic/SplashScreen/Localization/ar_SA.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">مساعدة</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">فتح إدارة الفيديو</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">الأسفل</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">استخدام تلاشي الرسوم المتحركة لصورة الشاشة</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">استخدام تلاشي الرسوم المتحركة لشعار الشاشة</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">إظهار مؤشر التحميل الدوار</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">حجم المؤشر الدوار (بالبكسل):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">شفافية المؤشر الدوار:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">سرعة المؤشر الدوار (ثوانٍ لكل دورة):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">معاينة:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">خلفية المعاينة:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">سُمك المؤشر الدوار (بالبكسل):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">عدد شرطات المؤشر الدوار:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">طول شرطة المؤشر الدوار (بالبكسل):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">استخدام نهايات مستديرة للشرطات</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">ضبط سرعة المؤشر الدوار تلقائيا حسب الحجم</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">حشوة المنطقة الآمنة (بالبكسل):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">شفافية صورة الخلفية:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">استخدام صورة بداية عامة لجميع الألعاب</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">استخدم شعار اللعبة في صورة البداية العالمية إذا كان متاحًا</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/ca_ES.xaml
+++ b/source/Generic/SplashScreen/Localization/ca_ES.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Fons de la previsualització:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Gruix de l'indicador (píxels):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Nombre de traços de l'indicador:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Longitud del traç de l'indicador (píxels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Longitud del traç de l'indicador (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Utilitza extrems arrodonits als traços</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Ajusta automàticament la velocitat segons la mida de l'indicador</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/ca_ES.xaml
+++ b/source/Generic/SplashScreen/Localization/ca_ES.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Mostra l'indicador de càrrega</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Mida de l'indicador (píxels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Opacitat de l'indicador:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Velocitat de l'indicador (segons per volta):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Vista prèvia:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Fons de la previsualització:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Gruix de l'indicador (píxels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Nombre de traços de l'indicador:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Longitud del traç de l'indicador (píxels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Utilitza extrems arrodonits als traços</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Ajusta automàticament la velocitat segons la mida de l'indicador</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Padding de l'àrea segura (píxels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Opacitat de la imatge de fons:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/cs_CZ.xaml
+++ b/source/Generic/SplashScreen/Localization/cs_CZ.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Zobrazit indikátor načítání</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Velikost indikátoru (pixely):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Průhlednost indikátoru:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Rychlost indikátoru (sekundy na otáčku):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Náhled:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Pozadí náhledu:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Tloušťka indikátoru (pixely):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Počet čárek indikátoru:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Délka čárky indikátoru (pixely):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Použít zaoblené konce čárek</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Automaticky upravit rychlost indikátoru podle jeho velikosti</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Odsazení bezpečné oblasti (pixely):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Průhlednost obrázku pozadí:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/cs_CZ.xaml
+++ b/source/Generic/SplashScreen/Localization/cs_CZ.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Pozadí náhledu:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Tloušťka indikátoru (pixely):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Počet čárek indikátoru:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Délka čárky indikátoru (pixely):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Délka čárky indikátoru (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Použít zaoblené konce čárek</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Automaticky upravit rychlost indikátoru podle jeho velikosti</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/da_DK.xaml
+++ b/source/Generic/SplashScreen/Localization/da_DK.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Forhåndsvisningsbaggrund:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Tykkelse på spinner (pixels):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Antal streger i spinner:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Længde på spinnerstreg (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Længde på spinnerstreg (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Brug afrundede stregeender</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Juster automatisk spinnerhastighed efter spinnerstørrelse</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/da_DK.xaml
+++ b/source/Generic/SplashScreen/Localization/da_DK.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Vis indlæsningsspinner</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Spinnerstørrelse (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Spinneropacitet:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Spinnerhastighed (sekunder pr. omdrejning):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Forhåndsvisning:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Forhåndsvisningsbaggrund:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Tykkelse på spinner (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Antal streger i spinner:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Længde på spinnerstreg (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Brug afrundede stregeender</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Juster automatisk spinnerhastighed efter spinnerstørrelse</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Sikkerhedsafstand (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Opacitet for baggrundsbillede:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/de_DE.xaml
+++ b/source/Generic/SplashScreen/Localization/de_DE.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Vorschauhintergrund:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Dicke des Spinners (Pixel):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Anzahl der Spinner-Striche:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Länge der Spinner-Striche (Pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Länge der Spinner-Striche (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Abgerundete Strichenden verwenden</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Spinner-Geschwindigkeit automatisch an die Spinnergröße anpassen</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/de_DE.xaml
+++ b/source/Generic/SplashScreen/Localization/de_DE.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Hilfe</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Video-Manager öffnen</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Unten</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Einblendungsanimation für den Startbildschirm verwenden</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Einblendungsanimation für das Logo auf dem Startbildschirm verwenden</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Ladespinner anzeigen</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Spinnergröße (Pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Spinner-Deckkraft:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Spinner-Geschwindigkeit (Sekunden pro Umdrehung):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Vorschau:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Vorschauhintergrund:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Dicke des Spinners (Pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Anzahl der Spinner-Striche:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Länge der Spinner-Striche (Pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Abgerundete Strichenden verwenden</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Spinner-Geschwindigkeit automatisch an die Spinnergröße anpassen</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Sicherheitsabstand (Pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Deckkraft des Hintergrundbilds:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Ein globales Splash Bild für alle Spiele verwenden</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Verwende das Spiellogo im globalen Splash Bild, falls verfügbar</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Einstellungen speichern</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Einstellungen gespeichert</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/en_US.xaml
+++ b/source/Generic/SplashScreen/Localization/en_US.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemAdd-DisableFeature">Disable extension for the selected games</sys:String>
@@ -35,6 +35,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Show loading spinner</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Spinner size (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Spinner opacity:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Spinner speed (seconds per turn):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Preview:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Preview background:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Spinner thickness (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Spinner dash count:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Spinner dash length (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Use rounded dash caps</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Adjust spinner speed automatically based on spinner size</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Safe area padding (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Background image opacity:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>

--- a/source/Generic/SplashScreen/Localization/en_US.xaml
+++ b/source/Generic/SplashScreen/Localization/en_US.xaml
@@ -43,7 +43,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Preview background:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Spinner thickness (pixels):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Spinner dash count:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Spinner dash length (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Spinner dash length (1-100% of segment):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Use rounded dash caps</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Adjust spinner speed automatically based on spinner size</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/eo_UY.xaml
+++ b/source/Generic/SplashScreen/Localization/eo_UY.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Fono de antaŭvido:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Dikeco de turnilo (rastrumeroj):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Nombro de streketoj de turnilo:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Longeco de streketo de turnilo (rastrumeroj):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Longeco de streketo de turnilo (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Uzi rondigitajn finojn de streketoj</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Aŭtomate adapti la rapidon de turnilo laŭ la grandeco</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/eo_UY.xaml
+++ b/source/Generic/SplashScreen/Localization/eo_UY.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Montri ŝargan turnilon</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Grandeco de turnilo (rastrumeroj):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Opakeco de turnilo:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Rapido de turnilo (sekundoj por turno):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Antaŭvido:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Fono de antaŭvido:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Dikeco de turnilo (rastrumeroj):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Nombro de streketoj de turnilo:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Longeco de streketo de turnilo (rastrumeroj):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Uzi rondigitajn finojn de streketoj</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Aŭtomate adapti la rapidon de turnilo laŭ la grandeco</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Sekura marĝeno (rastrumeroj):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Opakeco de fona bildo:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/es_ES.xaml
+++ b/source/Generic/SplashScreen/Localization/es_ES.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Fondo de la vista previa:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Grosor del indicador (píxeles):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Cantidad de trazos del indicador:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Longitud del trazo del indicador (píxeles):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Longitud del trazo del indicador (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Usar extremos redondeados en los trazos</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Ajustar automáticamente la velocidad según el tamaño del indicador</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/es_ES.xaml
+++ b/source/Generic/SplashScreen/Localization/es_ES.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Ayuda</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Abrir gestor de vídeo</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Abajo</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Usar animación de desvanecimiento para la imagen de la ventana de SplashScreen</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Usar animación de desvanecimiento para el logo de la ventana de SplashScreen</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Mostrar indicador de carga</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Tamaño del indicador (píxeles):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Opacidad del indicador:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Velocidad del indicador (segundos por vuelta):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Vista previa:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Fondo de la vista previa:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Grosor del indicador (píxeles):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Cantidad de trazos del indicador:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Longitud del trazo del indicador (píxeles):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Usar extremos redondeados en los trazos</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Ajustar automáticamente la velocidad según el tamaño del indicador</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Relleno del área segura (píxeles):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Opacidad de la imagen de fondo:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Usar una imagen global para todos los juegos</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Usa el logo del juego en la imagen global si está disponible</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Guardar configuración</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Configuración guardada</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/fa_IR.xaml
+++ b/source/Generic/SplashScreen/Localization/fa_IR.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">پس‌زمینه پیش‌نمایش:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">ضخامت نشانگر (پیکسل):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">تعداد خط‌چین‌های نشانگر:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">طول خط‌چین نشانگر (پیکسل):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">طول خط‌چین نشانگر (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">استفاده از سرخط‌های گرد</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">تنظیم خودکار سرعت نشانگر بر اساس اندازهٔ آن</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/fa_IR.xaml
+++ b/source/Generic/SplashScreen/Localization/fa_IR.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">نمایش نشانگر بارگذاری</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">اندازهٔ نشانگر (پیکسل):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">شفافیت نشانگر:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">سرعت نشانگر (ثانیه در هر دور):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">پیش‌نمایش:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">پس‌زمینه پیش‌نمایش:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">ضخامت نشانگر (پیکسل):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">تعداد خط‌چین‌های نشانگر:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">طول خط‌چین نشانگر (پیکسل):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">استفاده از سرخط‌های گرد</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">تنظیم خودکار سرعت نشانگر بر اساس اندازهٔ آن</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">فاصلهٔ ناحیهٔ امن (پیکسل):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">شفافیت تصویر پس‌زمینه:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/fi_FI.xaml
+++ b/source/Generic/SplashScreen/Localization/fi_FI.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Näytä latausikoni</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Pyörivän ilmaisimen koko (pikseleinä):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Pyörivän ilmaisimen peittävyys:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Pyörivän ilmaisimen nopeus (sekuntia/kierros):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Esikatselu:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Esikatselun tausta:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Pyörivän ilmaisimen paksuus (pikseleinä):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Pyörivän ilmaisimen viivojen määrä:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Pyörivän ilmaisimen viivan pituus (pikseleinä):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Käytä pyöristettyjä viivanpäitä</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Säädä pyörivän ilmaisimen nopeutta automaattisesti koon mukaan</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Turva-alueen reunus (pikseleinä):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Taustakuvan peittävyys:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/fi_FI.xaml
+++ b/source/Generic/SplashScreen/Localization/fi_FI.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Esikatselun tausta:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Pyörivän ilmaisimen paksuus (pikseleinä):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Pyörivän ilmaisimen viivojen määrä:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Pyörivän ilmaisimen viivan pituus (pikseleinä):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Pyörivän ilmaisimen viivan pituus (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Käytä pyöristettyjä viivanpäitä</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Säädä pyörivän ilmaisimen nopeutta automaattisesti koon mukaan</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/fr_FR.xaml
+++ b/source/Generic/SplashScreen/Localization/fr_FR.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Aide</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Ouvrir le gestionnaire de vidéos</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bas</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Utiliser un fondu pour l'image de démarrage</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Utiliser un fondu pour le logo de démarrage</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Afficher l'indicateur de chargement</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Taille de l'indicateur (pixels) :</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Opacité de l'indicateur :</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Vitesse de l'indicateur (secondes par tour) :</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Aperçu :</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Arriere-plan de l'aperçu :</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Épaisseur de l'indicateur (pixels) :</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Nombre de segments de l'indicateur :</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Longueur des segments de l'indicateur (pixels) :</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Utiliser des extrémités de segments arrondies</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Ajuster automatiquement la vitesse selon la taille de l'indicateur</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Marge de zone sûre (pixels) :</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Opacité de l'image d'arrière-plan :</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Utiliser une image de démarrage globale pour tous les jeux</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Utiliser le logo du jeu dans l'image de démarrage globale s'il est disponible</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Enregistrer les paramètres</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Paramètres enregistrés</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/fr_FR.xaml
+++ b/source/Generic/SplashScreen/Localization/fr_FR.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Arriere-plan de l'aperçu :</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Épaisseur de l'indicateur (pixels) :</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Nombre de segments de l'indicateur :</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Longueur des segments de l'indicateur (pixels) :</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Longueur des segments de l'indicateur (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Utiliser des extrémités de segments arrondies</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Ajuster automatiquement la vitesse selon la taille de l'indicateur</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/gl_ES.xaml
+++ b/source/Generic/SplashScreen/Localization/gl_ES.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Mostrar indicador de carga</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Tamaño do indicador (píxeles):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Opacidade do indicador:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Velocidade do indicador (segundos por volta):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Vista previa:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Fondo da vista previa:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Espesor do indicador (píxeles):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Cantidade de trazos do indicador:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lonxitude do trazo do indicador (píxeles):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Usar extremos redondeados no trazado</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Axustar automaticamente a velocidade segundo o tamaño do indicador</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Marxe da área segura (píxeles):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Opacidade da imaxe de fondo:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/gl_ES.xaml
+++ b/source/Generic/SplashScreen/Localization/gl_ES.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Fondo da vista previa:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Espesor do indicador (píxeles):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Cantidade de trazos do indicador:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lonxitude do trazo do indicador (píxeles):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lonxitude do trazo do indicador (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Usar extremos redondeados no trazado</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Axustar automaticamente a velocidade segundo o tamaño do indicador</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/hr_HR.xaml
+++ b/source/Generic/SplashScreen/Localization/hr_HR.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Pozadina pregleda:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Debljina indikatora (pikseli):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Broj crtica indikatora:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Duljina crtice indikatora (pikseli):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Duljina crtice indikatora (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Koristi zaobljene završetke crtica</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Automatski prilagodi brzinu indikatora prema veličini</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/hr_HR.xaml
+++ b/source/Generic/SplashScreen/Localization/hr_HR.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Prikaži indikator učitavanja</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Veličina indikatora (pikseli):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Neprozirnost indikatora:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Brzina indikatora (sekunde po okretu):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Pregled:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Pozadina pregleda:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Debljina indikatora (pikseli):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Broj crtica indikatora:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Duljina crtice indikatora (pikseli):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Koristi zaobljene završetke crtica</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Automatski prilagodi brzinu indikatora prema veličini</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Razmak sigurnog područja (pikseli):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Neprozirnost pozadinske slike:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/hu_HU.xaml
+++ b/source/Generic/SplashScreen/Localization/hu_HU.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Töltési jelző megjelenítése</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Jelző mérete (képpont):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Jelző átlátszósága:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Jelző sebessége (másodperc/fordulat):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Előnézet:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Előnézet háttere:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Jelző vastagsága (képpont):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Jelző vonásainak száma:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Jelző vonásának hossza (képpont):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Lekerekített vonásvégek használata</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">A jelző sebességének automatikus igazítása a méretéhez</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Biztonsági terület margója (képpont):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Háttérkép átlátszósága:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/hu_HU.xaml
+++ b/source/Generic/SplashScreen/Localization/hu_HU.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Előnézet háttere:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Jelző vastagsága (képpont):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Jelző vonásainak száma:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Jelző vonásának hossza (képpont):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Jelző vonásának hossza (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Lekerekített vonásvégek használata</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">A jelző sebességének automatikus igazítása a méretéhez</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/it_IT.xaml
+++ b/source/Generic/SplashScreen/Localization/it_IT.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Aiuto</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Apri gestore video</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">In basso</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Usa l'animazione di dissolvenza per l'immagine della schermata iniziale</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Usa l'animazione di dissolvenza per il logo della schermata iniziale</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Mostra indicatore di caricamento</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Dimensione indicatore (pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Opacità indicatore:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Velocità indicatore (secondi per giro):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Anteprima:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Sfondo anteprima:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Spessore indicatore (pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Numero trattini indicatore:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lunghezza trattino indicatore (pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Usa estremità arrotondate per i trattini</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Regola automaticamente la velocità in base alla dimensione dell'indicatore</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Margine area sicura (pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Opacità immagine di sfondo:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Usa un'immagine splash globale per tutti i giochi</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Usa il logo del gioco nell'immagine splash globale se è disponibile</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Salva impostazioni</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Impostazioni salvate</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/it_IT.xaml
+++ b/source/Generic/SplashScreen/Localization/it_IT.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Sfondo anteprima:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Spessore indicatore (pixel):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Numero trattini indicatore:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lunghezza trattino indicatore (pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lunghezza trattino indicatore (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Usa estremità arrotondate per i trattini</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Regola automaticamente la velocità in base alla dimensione dell'indicatore</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/ja_JP.xaml
+++ b/source/Generic/SplashScreen/Localization/ja_JP.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">プレビュー背景:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">スピナーの太さ (ピクセル):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">スピナーのダッシュ数:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">スピナーのダッシュ長 (ピクセル):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">スピナーのダッシュ長 (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">ダッシュ端を丸くする</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">スピナーサイズに応じて速度を自動調整する</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/ja_JP.xaml
+++ b/source/Generic/SplashScreen/Localization/ja_JP.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">ヘルプ</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">下</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">読み込みスピナーを表示</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">スピナーサイズ (ピクセル):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">スピナーの不透明度:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">スピナー速度 (1回転あたりの秒数):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">プレビュー:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">プレビュー背景:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">スピナーの太さ (ピクセル):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">スピナーのダッシュ数:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">スピナーのダッシュ長 (ピクセル):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">ダッシュ端を丸くする</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">スピナーサイズに応じて速度を自動調整する</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">セーフエリアの余白 (ピクセル):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">背景画像の不透明度:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/ko_KR.xaml
+++ b/source/Generic/SplashScreen/Localization/ko_KR.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">미리 보기 배경:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">스피너 두께(픽셀):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">스피너 대시 개수:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">스피너 대시 길이(픽셀):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">스피너 대시 길이 (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">둥근 대시 끝 사용</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">스피너 크기에 따라 속도를 자동으로 조정</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/ko_KR.xaml
+++ b/source/Generic/SplashScreen/Localization/ko_KR.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">로딩 스피너 표시</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">스피너 크기(픽셀):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">스피너 불투명도:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">스피너 속도(회전당 초):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">미리 보기:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">미리 보기 배경:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">스피너 두께(픽셀):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">스피너 대시 개수:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">스피너 대시 길이(픽셀):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">둥근 대시 끝 사용</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">스피너 크기에 따라 속도를 자동으로 조정</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">안전 영역 여백(픽셀):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">배경 이미지 불투명도:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/nl_NL.xaml
+++ b/source/Generic/SplashScreen/Localization/nl_NL.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Laadspinner weergeven</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Spinnergrootte (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Spinnerdekking:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Spinnersnelheid (seconden per omwenteling):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Voorbeeld:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Voorbeeldachtergrond:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Dikte van de spinner (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Aantal streepjes van de spinner:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lengte van spinnerstreepjes (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Afgeronde uiteinden voor streepjes gebruiken</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Spinnersnelheid automatisch aanpassen op basis van de spinnergrootte</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Veilige-gebied opvulling (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Dekking van achtergrondafbeelding:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/nl_NL.xaml
+++ b/source/Generic/SplashScreen/Localization/nl_NL.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Voorbeeldachtergrond:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Dikte van de spinner (pixels):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Aantal streepjes van de spinner:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lengte van spinnerstreepjes (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lengte van spinnerstreepjes (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Afgeronde uiteinden voor streepjes gebruiken</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Spinnersnelheid automatisch aanpassen op basis van de spinnergrootte</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/no_NO.xaml
+++ b/source/Generic/SplashScreen/Localization/no_NO.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Forhåndsvisningsbakgrunn:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Tykkelse på spinner (piksler):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Antall streker i spinner:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lengde på spinnerstrek (piksler):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lengde på spinnerstrek (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Bruk avrundede strekender</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Juster spinnerhastigheten automatisk basert på spinnerstørrelse</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/no_NO.xaml
+++ b/source/Generic/SplashScreen/Localization/no_NO.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Hjelp</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Åpne video-behandler</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Nederst</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Bruk inntoningsanimasjon for splash screen-bilde</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Bruk inntoningsanimasjon for splash screen-logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Vis lastespinner</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Spinnerstørrelse (piksler):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Spinneropasitet:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Spinnerhastighet (sekunder per omdreining):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Forhåndsvisning:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Forhåndsvisningsbakgrunn:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Tykkelse på spinner (piksler):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Antall streker i spinner:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Lengde på spinnerstrek (piksler):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Bruk avrundede strekender</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Juster spinnerhastigheten automatisk basert på spinnerstørrelse</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Sikkerhetsmarg (piksler):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Opasitet for bakgrunnsbilde:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Bruk et globalt bilde for alle spill</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Bruk spilllogo i globalt splashscreen-bilde hvis tilgjengelig</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Lagre innstillinger</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Innstillingene er lagret</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/pl_PL.xaml
+++ b/source/Generic/SplashScreen/Localization/pl_PL.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Pokaż wskaźnik ładowania</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Rozmiar wskaźnika (piksele):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Przezroczystość wskaźnika:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Szybkość wskaźnika (sekundy na obrót):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Podgląd:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Tło podglądu:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Grubość wskaźnika (piksele):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Liczba kresek wskaźnika:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Długość kreski wskaźnika (piksele):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Użyj zaokrąglonych zakończeń kresek</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Automatycznie dostosuj szybkość wskaźnika do jego rozmiaru</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Margines bezpiecznego obszaru (piksele):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Przezroczystość obrazu tła:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/pl_PL.xaml
+++ b/source/Generic/SplashScreen/Localization/pl_PL.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Tło podglądu:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Grubość wskaźnika (piksele):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Liczba kresek wskaźnika:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Długość kreski wskaźnika (piksele):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Długość kreski wskaźnika (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Użyj zaokrąglonych zakończeń kresek</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Automatycznie dostosuj szybkość wskaźnika do jego rozmiaru</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/pt_BR.xaml
+++ b/source/Generic/SplashScreen/Localization/pt_BR.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Fundo da pré-visualização:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Espessura do indicador (pixels):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Quantidade de traços do indicador:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Comprimento do tracejado do indicador (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Comprimento do traço do indicador (1-100% do segmento):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Usar extremidades arredondadas no tracejado</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Ajustar automaticamente a velocidade do indicador de acordo com o tamanho</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/pt_BR.xaml
+++ b/source/Generic/SplashScreen/Localization/pt_BR.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Ajuda</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Abrir gerenciador de vídeo</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Embaixo</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Usar animação esmaecer para a tela de abertura</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Usar a animação esmaecer para o logotipo da tela de abertura</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Mostrar indicador de carregamento</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Tamanho do indicador (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Opacidade do indicador:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Velocidade do indicador (segundos por volta):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Pré-visualização:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Fundo da pré-visualização:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Espessura do indicador (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Quantidade de traços do indicador:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Comprimento do tracejado do indicador (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Usar extremidades arredondadas no tracejado</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Ajustar automaticamente a velocidade do indicador de acordo com o tamanho</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Margem da área segura (pixels):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Opacidade da imagem de fundo:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Usar uma tela inicial de abertura padrão para todos os jogos</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Usa o logotipo do jogo na tela inicial padrão, se estiver disponível</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Salvar Configurações</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Configurações salvas</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/pt_PT.xaml
+++ b/source/Generic/SplashScreen/Localization/pt_PT.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Fundo da pré-visualização:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Espessura do indicador (píxeis):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Quantidade de traços do indicador:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Comprimento do tracejado do indicador (píxeis):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Comprimento do traço do indicador (1-100% do segmento):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Utilizar extremidades arredondadas no tracejado</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Ajustar automaticamente a velocidade do indicador com base no tamanho</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/pt_PT.xaml
+++ b/source/Generic/SplashScreen/Localization/pt_PT.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Mostrar indicador de carregamento</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Tamanho do indicador (píxeis):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Opacidade do indicador:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Velocidade do indicador (segundos por volta):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Pré-visualização:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Fundo da pré-visualização:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Espessura do indicador (píxeis):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Quantidade de traços do indicador:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Comprimento do tracejado do indicador (píxeis):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Utilizar extremidades arredondadas no tracejado</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Ajustar automaticamente a velocidade do indicador com base no tamanho</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Margem da área segura (píxeis):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Opacidade da imagem de fundo:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/ru_RU.xaml
+++ b/source/Generic/SplashScreen/Localization/ru_RU.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Справка</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Открыть менеджер видео</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Снизу</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Использовать анимацию затухания для изображения заставки</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Использовать анимацию затухания для изображения логотипа</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Показывать индикатор загрузки</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Размер индикатора (пиксели):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Непрозрачность индикатора:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Скорость индикатора (секунд за оборот):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Предпросмотр:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Фон предпросмотра:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Толщина индикатора (пиксели):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Количество штрихов индикатора:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Длина штриха индикатора (пиксели):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Использовать закругленные концы штрихов</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Автоматически подстраивать скорость индикатора под его размер</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Отступ безопасной зоны (пиксели):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Непрозрачность фонового изображения:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Использовать общее изображение заставки для всех игр</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Использовать логотип на общем изображении заставки, если доступен</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/ru_RU.xaml
+++ b/source/Generic/SplashScreen/Localization/ru_RU.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Фон предпросмотра:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Толщина индикатора (пиксели):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Количество штрихов индикатора:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Длина штриха индикатора (пиксели):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Длина штриха индикатора (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Использовать закругленные концы штрихов</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Автоматически подстраивать скорость индикатора под его размер</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/sr_SP.xaml
+++ b/source/Generic/SplashScreen/Localization/sr_SP.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Позадина прегледа:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Дебљина индикатора (пиксели):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Број цртица индикатора:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Дужина цртице индикатора (пиксели):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Дужина цртице индикатора (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Користи заобљене крајеве цртица</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Automatski prilagodi brzinu indikatora prema veličini</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/sr_SP.xaml
+++ b/source/Generic/SplashScreen/Localization/sr_SP.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Prikaži indikator učitavanja</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Veličina indikatora (pikseli):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Providnost indikatora:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Brzina indikatora (sekundi po obrtaju):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Преглед:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Позадина прегледа:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Дебљина индикатора (пиксели):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Број цртица индикатора:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Дужина цртице индикатора (пиксели):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Користи заобљене крајеве цртица</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Automatski prilagodi brzinu indikatora prema veličini</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Razmak bezbedne zone (pikseli):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Непрозирност позадинске слике:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/tr_TR.xaml
+++ b/source/Generic/SplashScreen/Localization/tr_TR.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Önizleme arka planı:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Gösterge kalınlığı (piksel):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Gösterge çizgi sayısı:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Gösterge çizgi uzunluğu (piksel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Gösterge çizgi uzunluğu (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Yuvarlatılmış çizgi uçlarını kullan</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Gösterge hızını boyuta göre otomatik ayarla</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/tr_TR.xaml
+++ b/source/Generic/SplashScreen/Localization/tr_TR.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Yardım</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Video yöneticisini aç</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Alt</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Açılış ekranı görüntüsü için yavaş yavaş beliren animasyonu kullanın</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Açılış ekranı logosu için yavaş yavaş beliren animasyonu kullanın</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Yükleme göstergesini göster</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Gösterge boyutu (piksel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Gösterge opaklığı:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Gösterge hızı (tur başına saniye):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Önizleme:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Önizleme arka planı:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Gösterge kalınlığı (piksel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Gösterge çizgi sayısı:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Gösterge çizgi uzunluğu (piksel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Yuvarlatılmış çizgi uçlarını kullan</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Gösterge hızını boyuta göre otomatik ayarla</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Güvenli alan boşluğu (piksel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Arka plan görseli opaklığı:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Tüm oyunlar için genel açılış görüntüsünü kullanın</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Varsa genel açılış görselinde oyun logosunu kullanın</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Ayarları kaydet</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Ayarlar kaydedildi</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/uk_UA.xaml
+++ b/source/Generic/SplashScreen/Localization/uk_UA.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Довідка</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Відкрити менеджер відео</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Внизу</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Використовувати анімацію появи для зображення екрана-заставки</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Використовувати анімацію появи для логотипа екрана-заставки</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Показувати індикатор завантаження</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Розмір індикатора (пікселі):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Непрозорість індикатора:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Швидкість індикатора (секунди за оберт):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Попередній перегляд:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Тло попереднього перегляду:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Товщина індикатора (пікселі):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Кількість штрихів індикатора:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Довжина штриха індикатора (пікселі):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Використовувати заокруглені кінці штрихів</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Автоматично підлаштовувати швидкість індикатора під його розмір</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Відступ безпечної зони (пікселі):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Непрозорість фонового зображення:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Використовувати глобальну екран-заставку для всіх ігор</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Використовувати логотип гри на глобальному екрані-заставці при наявності</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Зберегти налаштування</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Налаштування збережено</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/uk_UA.xaml
+++ b/source/Generic/SplashScreen/Localization/uk_UA.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Тло попереднього перегляду:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Товщина індикатора (пікселі):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Кількість штрихів індикатора:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Довжина штриха індикатора (пікселі):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Довжина штриха індикатора (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Використовувати заокруглені кінці штрихів</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Автоматично підлаштовувати швидкість індикатора під його розмір</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/vi_VN.xaml
+++ b/source/Generic/SplashScreen/Localization/vi_VN.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">Hiển thị vòng xoay tải</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">Kích thước vòng xoay (pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">Độ mờ vòng xoay:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">Tốc độ vòng xoay (giây mỗi vòng):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">Xem trước:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Nền xem trước:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Độ dày vòng xoay (pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Số lượng nét đứt của vòng xoay:</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Độ dài nét đứt của vòng xoay (pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Sử dụng đầu nét bo tròn</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Tự động điều chỉnh tốc độ theo kích thước vòng xoay</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">Lề vùng an toàn (pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">Độ mờ ảnh nền:</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/vi_VN.xaml
+++ b/source/Generic/SplashScreen/Localization/vi_VN.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">Nền xem trước:</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">Độ dày vòng xoay (pixel):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">Số lượng nét đứt của vòng xoay:</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Độ dài nét đứt của vòng xoay (pixel):</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">Độ dài nét đứt của vòng xoay (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">Sử dụng đầu nét bo tròn</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">Tự động điều chỉnh tốc độ theo kích thước vòng xoay</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/zh_CN.xaml
+++ b/source/Generic/SplashScreen/Localization/zh_CN.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">预览背景：</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">指示器粗细（像素）：</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">指示器短划线数量：</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">指示器短划线长度（像素）：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">指示器短划线长度 (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">使用圆角短划线端帽</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">根据指示器大小自动调整速度</sys:String>
 

--- a/source/Generic/SplashScreen/Localization/zh_CN.xaml
+++ b/source/Generic/SplashScreen/Localization/zh_CN.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">帮助</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">打开视频管理器</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">底</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">对序幕屏图像使用淡入动画</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">对序幕屏徽标使用淡入动画</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">显示加载指示器</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">指示器大小（像素）：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">指示器不透明度：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">指示器速度（每圈秒数）：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">预览：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">预览背景：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">指示器粗细（像素）：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">指示器短划线数量：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">指示器短划线长度（像素）：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">使用圆角短划线端帽</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">根据指示器大小自动调整速度</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">安全区域边距（像素）：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">背景图片不透明度：</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">为所有游戏使用一个全局的序幕图像</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">如果可用，在全局序幕图像中使用游戏徽标</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/zh_TW.xaml
+++ b/source/Generic/SplashScreen/Localization/zh_TW.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LOCSplashScreen_SettingsHelpLabel">Help</sys:String>
     <sys:String x:Key="LOCSplashScreen_MenuItemInvoke-OpenVideoManagerWindowDescription">Open video manager</sys:String>
@@ -36,6 +36,20 @@
     <sys:String x:Key="LOCSplashScreen_SettingVerticalAlignmentBottomLabel">Bottom</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashImageUseFadeInAnimationLabel">Use fade-in animation for the splash screen image</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSplashLogoUseFadeInAnimationLabel">Use fade-in animation for the splash screen logo</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingShowLoadingSpinnerLabel">顯示載入指示器</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSizeLabel">指示器大小（像素）：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerOpacityLabel">指示器不透明度：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerSpeedLabel">指示器速度（每圈秒數）：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewLabel">預覽：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">預覽背景：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">指示器粗細（像素）：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">指示器虛線數量：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">指示器虛線長度（像素）：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">使用圓角虛線端點</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">根據指示器大小自動調整速度</sys:String>
+
+    <sys:String x:Key="LOCSplashScreen_SettingSafeAreaPaddingLabel">安全區域邊距（像素）：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingBackgroundImageOpacityLabel">背景圖片不透明度：</sys:String>
     
     <sys:String x:Key="LOCSplashScreen_SettingUseGlobalSplashImage">Use a global splash image for all games</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingUseLogoGlobalSplashImage">Use game logo in global splash image if it's available</sys:String>
@@ -57,3 +71,4 @@
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSaveSettingsLabel">Save settings</sys:String>
     <sys:String x:Key="LOCSplashScreen_GameSettingsWindowSettingsSavedLabel">Settings saved</sys:String>
 </ResourceDictionary>
+

--- a/source/Generic/SplashScreen/Localization/zh_TW.xaml
+++ b/source/Generic/SplashScreen/Localization/zh_TW.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel">預覽背景：</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerThicknessLabel">指示器粗細（像素）：</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashCountLabel">指示器虛線數量：</sys:String>
-    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">指示器虛線長度（像素）：</sys:String>
+    <sys:String x:Key="LOCSplashScreen_SettingSpinnerDashLengthLabel">指示器虛線長度 (1-100%):</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerRoundedDashesLabel">使用圓角虛線端點</sys:String>
     <sys:String x:Key="LOCSplashScreen_SettingSpinnerAutoSpeedLabel">根據指示器大小自動調整速度</sys:String>
 

--- a/source/Generic/SplashScreen/Models/GeneralSplashSettings.cs
+++ b/source/Generic/SplashScreen/Models/GeneralSplashSettings.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace SplashScreen.Models

--- a/source/Generic/SplashScreen/Models/GeneralSplashSettings.cs
+++ b/source/Generic/SplashScreen/Models/GeneralSplashSettings.cs
@@ -90,7 +90,7 @@ namespace SplashScreen.Models
         double LoadingSpinnerThickness { get; set; }
 
         /// <summary>
-        /// Gets or sets loading spinner dash length in pixels.
+        /// Gets or sets loading spinner dash length as a percentage of each dash slot.
         /// </summary>
         double LoadingSpinnerDashLength { get; set; }
 
@@ -143,7 +143,7 @@ namespace SplashScreen.Models
         public int LoadingSpinnerSize { get; set; } = 50;
         public double LoadingSpinnerOpacity { get; set; } = 0.85;
         public double LoadingSpinnerThickness { get; set; } = 2.0;
-        public double LoadingSpinnerDashLength { get; set; } = 4.0;
+        public double LoadingSpinnerDashLength { get; set; } = 70.0;
         public int LoadingSpinnerDashCount { get; set; } = 16;
         public bool LoadingSpinnerRoundedDashes { get; set; } = false;
         public double LoadingSpinnerRotationSeconds { get; set; } = 3.0;

--- a/source/Generic/SplashScreen/Models/GeneralSplashSettings.cs
+++ b/source/Generic/SplashScreen/Models/GeneralSplashSettings.cs
@@ -68,6 +68,61 @@ namespace SplashScreen.Models
         /// Gets or sets Fullscreen Mode specific settings.
         /// </summary>
         ModeSplashSettings FullscreenModeSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether loading spinner should be displayed.
+        /// </summary>
+        bool EnableLoadingSpinner { get; set; }
+
+        /// <summary>
+        /// Gets or sets loading spinner size in pixels.
+        /// </summary>
+        int LoadingSpinnerSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets loading spinner opacity.
+        /// </summary>
+        double LoadingSpinnerOpacity { get; set; }
+
+        /// <summary>
+        /// Gets or sets loading spinner stroke thickness in pixels.
+        /// </summary>
+        double LoadingSpinnerThickness { get; set; }
+
+        /// <summary>
+        /// Gets or sets loading spinner dash length in pixels.
+        /// </summary>
+        double LoadingSpinnerDashLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets loading spinner dash count.
+        /// </summary>
+        int LoadingSpinnerDashCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether spinner dashes should have rounded caps.
+        /// </summary>
+        bool LoadingSpinnerRoundedDashes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base spinner rotation duration in seconds.
+        /// </summary>
+        double LoadingSpinnerRotationSeconds { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether spinner speed should be adjusted by spinner size.
+        /// </summary>
+        bool EnableLoadingSpinnerAutoSpeed { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the safe area padding in pixels used by logo and loading spinner.
+        /// </summary>
+        int SafeAreaPadding { get; set; }
+
+        /// <summary>
+        /// Gets or sets background image opacity.
+        /// </summary>
+        double BackgroundImageOpacity { get; set; }
     }
 
     public class GeneralSplashSettings : IGeneralSplashSettings
@@ -84,5 +139,16 @@ namespace SplashScreen.Models
         public VerticalAlignment LogoVerticalAlignment { get; set; } = VerticalAlignment.Bottom;
         public ModeSplashSettings DesktopModeSettings { get; set; } = new ModeSplashSettings();
         public ModeSplashSettings FullscreenModeSettings { get; set; } = new ModeSplashSettings();
+        public bool EnableLoadingSpinner { get; set; } = true;
+        public int LoadingSpinnerSize { get; set; } = 50;
+        public double LoadingSpinnerOpacity { get; set; } = 0.85;
+        public double LoadingSpinnerThickness { get; set; } = 2.0;
+        public double LoadingSpinnerDashLength { get; set; } = 4.0;
+        public int LoadingSpinnerDashCount { get; set; } = 16;
+        public bool LoadingSpinnerRoundedDashes { get; set; } = false;
+        public double LoadingSpinnerRotationSeconds { get; set; } = 3.0;
+        public bool EnableLoadingSpinnerAutoSpeed { get; set; } = true;
+        public int SafeAreaPadding { get; set; } = 60;
+        public double BackgroundImageOpacity { get; set; } = 0.60;
     }
 }

--- a/source/Generic/SplashScreen/SplashScreen.cs
+++ b/source/Generic/SplashScreen/SplashScreen.cs
@@ -5,6 +5,7 @@ using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
 using PlayniteUtilitiesCommon;
 using PluginsCommon;
+using SplashScreen.Helpers;
 using SplashScreen.Models;
 using SplashScreen.ViewModels;
 using SplashScreen.Views;
@@ -196,6 +197,7 @@ namespace SplashScreen
                 var gameSplashSettings = Serialization.FromJsonFile<GameSplashSettings>(gameSettingsPath);
                 if (gameSplashSettings.EnableGameSpecificSettings)
                 {
+                    SplashSettingsSyncHelper.ApplyGlobalIndicatorSettings(gameSplashSettings.GeneralSplashSettings, settings.Settings.GeneralSplashSettings);
                     return gameSplashSettings.GeneralSplashSettings;
                 }
             }
@@ -580,7 +582,7 @@ namespace SplashScreen
             window.Title = "Splash Screen";
 
             window.Content = new GameSettingsWindow();
-            window.DataContext = new GameSettingsWindowViewModel(PlayniteApi, GetPluginUserDataPath(), game);
+            window.DataContext = new GameSettingsWindowViewModel(PlayniteApi, GetPluginUserDataPath(), game, settings.Settings.GeneralSplashSettings);
             window.Owner = PlayniteApi.Dialogs.GetCurrentAppWindow();
             window.WindowStartupLocation = WindowStartupLocation.CenterScreen;
 

--- a/source/Generic/SplashScreen/SplashScreen.cs
+++ b/source/Generic/SplashScreen/SplashScreen.cs
@@ -26,13 +26,13 @@ namespace SplashScreen
 {
     public class SplashScreen : GenericPlugin
     {
-        private static readonly ILogger logger = LogManager.GetLogger();
-        private readonly DispatcherTimer timerCloseWindow;
-        private string pluginInstallPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        private Window currentSplashWindow;
-        private bool? isMusicMutedBackup;
-        private EventWaitHandle videoWaitHandle;
-        private readonly DispatcherTimer timerWindowRemoveTopMost;
+        private static readonly ILogger _logger = LogManager.GetLogger();
+        private readonly DispatcherTimer _timerCloseWindow;
+        private string _pluginInstallPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        private Window _currentSplashWindow;
+        private bool? _isMusicMutedBackup;
+        private EventWaitHandle _videoWaitHandle;
+        private readonly DispatcherTimer _timerWindowRemoveTopMost;
         private const string featureNameSplashScreenDisable = "[Splash Screen] Disable";
         private const string featureNameSkipSplashImage = "[Splash Screen] Skip splash image";
         private const string videoIntroName = "VideoIntro.mp4";
@@ -50,23 +50,23 @@ namespace SplashScreen
                 HasSettings = true
             };
 
-            videoWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset);
-            timerCloseWindow = new DispatcherTimer();
-            timerCloseWindow.Interval = TimeSpan.FromMilliseconds(60000);
-            timerCloseWindow.Tick += (_, __) =>
+            _videoWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset);
+            _timerCloseWindow = new DispatcherTimer();
+            _timerCloseWindow.Interval = TimeSpan.FromMilliseconds(60000);
+            _timerCloseWindow.Tick += (_, __) =>
             {
-                timerCloseWindow.Stop();
-                currentSplashWindow?.Close();
+                _timerCloseWindow.Stop();
+                _currentSplashWindow?.Close();
             };
 
-            timerWindowRemoveTopMost = new DispatcherTimer();
-            timerWindowRemoveTopMost.Interval = TimeSpan.FromMilliseconds(800);
-            timerWindowRemoveTopMost.Tick += (_, __) =>
+            _timerWindowRemoveTopMost = new DispatcherTimer();
+            _timerWindowRemoveTopMost.Interval = TimeSpan.FromMilliseconds(800);
+            _timerWindowRemoveTopMost.Tick += (_, __) =>
             {
-                timerWindowRemoveTopMost.Stop();
-                if (currentSplashWindow != null)
+                _timerWindowRemoveTopMost.Stop();
+                if (_currentSplashWindow != null)
                 {
-                    currentSplashWindow.Topmost = false;
+                    _currentSplashWindow.Topmost = false;
                 }
             };
         }
@@ -81,7 +81,7 @@ namespace SplashScreen
             if (PlayniteApi.ApplicationSettings.Fullscreen.IsMusicMuted == false)
             {
                 PlayniteApi.ApplicationSettings.Fullscreen.IsMusicMuted = true;
-                isMusicMutedBackup = false;
+                _isMusicMutedBackup = false;
             }
         }
 
@@ -92,18 +92,18 @@ namespace SplashScreen
                 return;
             }
 
-            if (isMusicMutedBackup != null && isMusicMutedBackup == false)
+            if (_isMusicMutedBackup != null && _isMusicMutedBackup == false)
             {
                 PlayniteApi.ApplicationSettings.Fullscreen.IsMusicMuted = false;
-                isMusicMutedBackup = null;
+                _isMusicMutedBackup = null;
             }
         }
 
         public override void OnGameStarted(OnGameStartedEventArgs args)
         {
-            if (currentSplashWindow != null)
+            if (_currentSplashWindow != null)
             {
-                currentSplashWindow.Topmost = false;
+                _currentSplashWindow.Topmost = false;
             }
         }
 
@@ -115,22 +115,22 @@ namespace SplashScreen
                                 ? generalSplashSettings.DesktopModeSettings : generalSplashSettings.FullscreenModeSettings;
             if (!modeSplashSettings.IsEnabled)
             {
-                logger.Info($"Execution disabled for {PlayniteApi.ApplicationInfo.Mode} mode in settings");
+                _logger.Info($"Execution disabled for {PlayniteApi.ApplicationInfo.Mode} mode in settings");
                 return;
             }
 
             // In case somebody starts another game or if splash screen was not closed before for some reason
-            if (currentSplashWindow != null)
+            if (_currentSplashWindow != null)
             {
-                currentSplashWindow.Close();
-                currentSplashWindow = null;
+                _currentSplashWindow.Close();
+                _currentSplashWindow = null;
                 RestoreBackgroundMusic();
             }
 
-            currentSplashWindow = null;
+            _currentSplashWindow = null;
             if (PlayniteUtilities.GetGameHasFeature(game, featureNameSplashScreenDisable, true))
             {
-                logger.Info($"{game.Name} has splashscreen disable feature");
+                _logger.Info($"{game.Name} has splashscreen disable feature");
                 return;
             }
 
@@ -159,7 +159,7 @@ namespace SplashScreen
                 {
                     if (generalSplashSettings.UseBlackSplashscreen)
                     {
-                        splashImagePath = Path.Combine(pluginInstallPath, "Images", "SplashScreenBlack.png");
+                        splashImagePath = Path.Combine(_pluginInstallPath, "Images", "SplashScreenBlack.png");
                     }
                     else
                     {
@@ -229,13 +229,13 @@ namespace SplashScreen
         
         private void SkipSplash(object sender, EventArgs e)
         {
-            if (currentSplashWindow.Content is SplashScreenVideo)
+            if (_currentSplashWindow.Content is SplashScreenVideo)
             {
-                videoWaitHandle.Set();
+                _videoWaitHandle.Set();
             }
             else
             {
-                currentSplashWindow.Close();
+                _currentSplashWindow.Close();
             }
         }
 
@@ -244,11 +244,11 @@ namespace SplashScreen
             // Mutes Playnite Background music to make sure its not playing when video or splash screen image
             // is active and prevents music not stopping when game is already running
             MuteBackgroundMusic();
-            timerCloseWindow.Stop();
-            currentSplashWindow?.Close();
+            _timerCloseWindow.Stop();
+            _currentSplashWindow?.Close();
 
             var content = new SplashScreenVideo(videoPath);
-            currentSplashWindow = new Window
+            _currentSplashWindow = new Window
             {
                 WindowStyle = WindowStyle.None,
                 ResizeMode = ResizeMode.NoResize,
@@ -259,70 +259,70 @@ namespace SplashScreen
                 Topmost = true
             };
 
-            currentSplashWindow.Closed += SplashWindowClosed;
+            _currentSplashWindow.Closed += SplashWindowClosed;
             content.VideoPlayer.MediaEnded += VideoPlayer_MediaEnded;
             content.VideoPlayer.MediaFailed += VideoPlayer_MediaFailed;
-            currentSplashWindow.KeyDown += SkipSplash;
-            currentSplashWindow.MouseDown += SkipSplash;
+            _currentSplashWindow.KeyDown += SkipSplash;
+            _currentSplashWindow.MouseDown += SkipSplash;
 
-            currentSplashWindow.Show();
+            _currentSplashWindow.Show();
 
             // To wait until the video stops playing, a progress dialog is used
             // to make Playnite wait in a non locking way and without sleeping the whole
             // application
-            videoWaitHandle.Reset();
+            _videoWaitHandle.Reset();
             PlayniteApi.Dialogs.ActivateGlobalProgress((_) =>
             {
-                ActivateSplashWindow(currentSplashWindow);
-                videoWaitHandle.WaitOne();
+                ActivateSplashWindow(_currentSplashWindow);
+                _videoWaitHandle.WaitOne();
                 content.VideoPlayer.MediaEnded -= VideoPlayer_MediaEnded;
                 content.VideoPlayer.MediaFailed -= VideoPlayer_MediaFailed;
-                logger.Debug("videoWaitHandle.WaitOne() passed");
+                _logger.Debug("videoWaitHandle.WaitOne() passed");
             }, new GlobalProgressOptions(string.Empty) { IsIndeterminate = false });
 
             if (showSplashImage)
             {
-                currentSplashWindow.Content = new SplashScreenImage { DataContext = new SplashScreenImageViewModel(generalSplashSettings, splashImagePath, logoPath) };
+                _currentSplashWindow.Content = new SplashScreenImage { DataContext = new SplashScreenImageViewModel(generalSplashSettings, splashImagePath, logoPath) };
                 PlayniteApi.Dialogs.ActivateGlobalProgress((a) =>
                 {
-                    ActivateSplashWindow(currentSplashWindow);
+                    ActivateSplashWindow(_currentSplashWindow);
                     Thread.Sleep(3000);
                 }, new GlobalProgressOptions(string.Empty) { IsIndeterminate = false });
 
                 if (modeSplashSettings.CloseSplashscreenAutomatic)
                 {
-                    timerCloseWindow.Stop();
-                    timerCloseWindow.Start();
+                    _timerCloseWindow.Stop();
+                    _timerCloseWindow.Start();
                 }
             }
             else
             {
-                currentSplashWindow?.Close();
+                _currentSplashWindow?.Close();
             }
 
-            timerWindowRemoveTopMost.Stop();
-            timerWindowRemoveTopMost.Start();
+            _timerWindowRemoveTopMost.Stop();
+            _timerWindowRemoveTopMost.Start();
         }
 
         private void VideoPlayer_MediaEnded(object sender, RoutedEventArgs e)
         {
-            videoWaitHandle.Set();
+            _videoWaitHandle.Set();
         }
 
         private void VideoPlayer_MediaFailed(object sender, ExceptionRoutedEventArgs e)
         {
-            videoWaitHandle.Set();
+            _videoWaitHandle.Set();
         }
 
         private void CreateSplashImageWindow(string splashImagePath, string logoPath, GeneralSplashSettings generalSplashSettings, ModeSplashSettings modeSplashSettings)
         {
             // Mutes Playnite Background music to make sure its not playing when video or splash screen image
             // is active and prevents music not stopping when game is already running
-            timerCloseWindow.Stop();
+            _timerCloseWindow.Stop();
 
-            currentSplashWindow?.Close();
+            _currentSplashWindow?.Close();
             MuteBackgroundMusic();
-            currentSplashWindow = new Window
+            _currentSplashWindow = new Window
             {
                 WindowStyle = WindowStyle.None,
                 ResizeMode = ResizeMode.NoResize,
@@ -333,39 +333,39 @@ namespace SplashScreen
                 Topmost = true
             };
 
-            currentSplashWindow.Closed += SplashWindowClosed;
-            currentSplashWindow.KeyDown += SkipSplash;
-            currentSplashWindow.MouseDown += SkipSplash;
+            _currentSplashWindow.Closed += SplashWindowClosed;
+            _currentSplashWindow.KeyDown += SkipSplash;
+            _currentSplashWindow.MouseDown += SkipSplash;
             
-            currentSplashWindow.Show();
+            _currentSplashWindow.Show();
             
             PlayniteApi.Dialogs.ActivateGlobalProgress((a) =>
             {
-                ActivateSplashWindow(currentSplashWindow);
+                ActivateSplashWindow(_currentSplashWindow);
                 Thread.Sleep(3000);
             }, new GlobalProgressOptions(string.Empty) { IsIndeterminate = false});
 
             if (modeSplashSettings.CloseSplashscreenAutomatic)
             {
-                timerCloseWindow.Stop();
-                timerCloseWindow.Start();
+                _timerCloseWindow.Stop();
+                _timerCloseWindow.Start();
             }
 
             // The window topmost property is set to false after a small time to make sure
             // Playnite does not restore itself over the created window after the method ends
             // and it starts launching the game
-            timerWindowRemoveTopMost.Stop();
-            timerWindowRemoveTopMost.Start();
+            _timerWindowRemoveTopMost.Stop();
+            _timerWindowRemoveTopMost.Start();
         }
 
         private void SplashWindowClosed(object sender, EventArgs e)
         {
-            timerCloseWindow.Stop();
-            videoWaitHandle.Set();
-            currentSplashWindow.Closed -= SplashWindowClosed;
-            currentSplashWindow.KeyDown -= SkipSplash;
-            currentSplashWindow.MouseDown -= SkipSplash;
-            currentSplashWindow = null;
+            _timerCloseWindow.Stop();
+            _videoWaitHandle.Set();
+            _currentSplashWindow.Closed -= SplashWindowClosed;
+            _currentSplashWindow.KeyDown -= SkipSplash;
+            _currentSplashWindow.MouseDown -= SkipSplash;
+            _currentSplashWindow = null;
         }
 
         private string GetSplashVideoPath(Game game, ModeSplashSettings modeSplashSettings)
@@ -376,7 +376,7 @@ namespace SplashScreen
             var splashVideo = Path.Combine(baseSplashVideo, videoIntroName);
             if (FileSystem.FileExists(splashVideo))
             {
-                logger.Info(string.Format("Specific game video found in {0}", splashVideo));
+                _logger.Info(string.Format("Specific game video found in {0}", splashVideo));
                 return LogAcquiredVideo("Game-specific", splashVideo);
             }
 
@@ -418,14 +418,14 @@ namespace SplashScreen
             }
             else
             {
-                logger.Info("Video not found");
+                _logger.Info("Video not found");
                 return string.Empty;
             }
         }
 
         private static string LogAcquiredVideo(string source, string videoPath)
         {
-            logger.Info($"{source} video found in {videoPath}");
+            _logger.Info($"{source} video found in {videoPath}");
             return videoPath;
         }
 
@@ -433,7 +433,7 @@ namespace SplashScreen
         {
             if (generalSplashSettings.LogoUseIconAsLogo && game.Icon != null && !game.Icon.StartsWith("http"))
             {
-                logger.Info("Found game icon");
+                _logger.Info("Found game icon");
                 return PlayniteApi.Database.GetFullFilePath(game.Icon);
             }
             else
@@ -441,12 +441,12 @@ namespace SplashScreen
                 var logoPathSearch = Path.Combine(PlayniteApi.Paths.ConfigurationPath, "ExtraMetadata", "games", game.Id.ToString(), "Logo.png");
                 if (FileSystem.FileExists(logoPathSearch))
                 {
-                    logger.Info(string.Format("Specific game logo found in {0}", logoPathSearch));
+                    _logger.Info(string.Format("Specific game logo found in {0}", logoPathSearch));
                     return logoPathSearch;
                 }
             }
 
-            logger.Info("Logo not found");
+            _logger.Info("Logo not found");
             return string.Empty;
         }
 
@@ -454,25 +454,25 @@ namespace SplashScreen
         {
             if (game.BackgroundImage != null && !game.BackgroundImage.StartsWith("http"))
             {
-                logger.Info("Found game background image");
+                _logger.Info("Found game background image");
                 return PlayniteApi.Database.GetFullFilePath(game.BackgroundImage);
             }
 
             if (game.Platforms.HasItems() && game.Platforms[0].Background != null)
             {
-                logger.Info("Found platform background image");
+                _logger.Info("Found platform background image");
                 return PlayniteApi.Database.GetFullFilePath(game.Platforms[0].Background);
             }
 
             if (PlayniteApi.ApplicationInfo.Mode == ApplicationMode.Desktop)
             {
-                logger.Info("Using generic Desktop mode background image");
-                return Path.Combine(pluginInstallPath, "Images", "SplashScreenDesktopMode.png");
+                _logger.Info("Using generic Desktop mode background image");
+                return Path.Combine(_pluginInstallPath, "Images", "SplashScreenDesktopMode.png");
             }
             else
             {
-                logger.Info("Using generic Fullscreen mode background image");
-                return Path.Combine(pluginInstallPath, "Images", "SplashScreenFullscreenMode.png");
+                _logger.Info("Using generic Fullscreen mode background image");
+                return Path.Combine(_pluginInstallPath, "Images", "SplashScreenFullscreenMode.png");
             }
         }
 
@@ -480,10 +480,10 @@ namespace SplashScreen
         {
             RestoreBackgroundMusic();
             // Close splash screen manually it was not closed automatically
-            if (currentSplashWindow != null)
+            if (_currentSplashWindow != null)
             {
-                currentSplashWindow.Close();
-                currentSplashWindow = null;
+                _currentSplashWindow.Close();
+                _currentSplashWindow = null;
             }
         }
 

--- a/source/Generic/SplashScreen/SplashScreen.csproj
+++ b/source/Generic/SplashScreen/SplashScreen.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Models\GeneralSplashSettings.cs" />
     <Compile Include="Helpers\SplashSettingsSyncHelper.cs" />
     <Compile Include="Helpers\SpinnerGeometryBuilder.cs" />
+    <Compile Include="Helpers\SpinnerRenderHelper.cs" />
     <Compile Include="Models\ModeSplashSettings.cs" />
     <Compile Include="Models\VideoManagerItem.cs" />
     <Compile Include="SplashScreen.cs" />

--- a/source/Generic/SplashScreen/SplashScreen.csproj
+++ b/source/Generic/SplashScreen/SplashScreen.csproj
@@ -97,6 +97,8 @@
     </Compile>
     <Compile Include="Models\GameSplashSettings.cs" />
     <Compile Include="Models\GeneralSplashSettings.cs" />
+    <Compile Include="Helpers\SplashSettingsSyncHelper.cs" />
+    <Compile Include="Helpers\SpinnerGeometryBuilder.cs" />
     <Compile Include="Models\ModeSplashSettings.cs" />
     <Compile Include="Models\VideoManagerItem.cs" />
     <Compile Include="SplashScreen.cs" />
@@ -110,6 +112,9 @@
     <Compile Include="ViewModels\VideoManagerViewModel.cs" />
     <Compile Include="Views\GameSettingsWindow.xaml.cs">
       <DependentUpon>GameSettingsWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\SpinnerPreviewControl.xaml.cs">
+      <DependentUpon>SpinnerPreviewControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\SplashScreenImage.xaml.cs">
       <DependentUpon>SplashScreenImage.xaml</DependentUpon>
@@ -137,6 +142,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\GameSettingsWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SpinnerPreviewControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/source/Generic/SplashScreen/SplashScreenSettings.cs
+++ b/source/Generic/SplashScreen/SplashScreenSettings.cs
@@ -5,9 +5,6 @@ using SplashScreen.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace SplashScreen
@@ -48,20 +45,20 @@ namespace SplashScreen
 
     public class SplashScreenSettingsViewModel : ObservableObject, ISettings
     {
-        private readonly SplashScreen plugin;
-        private readonly string pluginUserDataPath;
-        private readonly IPlayniteAPI playniteApi;
-        private static readonly ILogger logger = LogManager.GetLogger();
+        private readonly SplashScreen _plugin;
+        private readonly string _pluginUserDataPath;
+        private readonly IPlayniteAPI _playniteApi;
+        private static readonly ILogger _logger = LogManager.GetLogger();
 
         private SplashScreenSettings editingClone { get; set; }
 
-        private SplashScreenSettings settings;
+        private SplashScreenSettings _settings;
         public SplashScreenSettings Settings
         {
-            get => settings;
+            get => _settings;
             set
             {
-                settings = value;
+                _settings = value;
                 OnPropertyChanged();
             }
         }
@@ -69,10 +66,10 @@ namespace SplashScreen
         public SplashScreenSettingsViewModel(SplashScreen plugin, IPlayniteAPI playniteApi, string pluginUserDataPath)
         {
             // Injecting your plugin instance is required for Save/Load method because Playnite saves data to a location based on what plugin requested the operation.
-            this.plugin = plugin;
+            this._plugin = plugin;
 
             // Load saved settings.
-            var savedSettings = plugin.LoadPluginSettings<SplashScreenSettings>();
+            var savedSettings = _plugin.LoadPluginSettings<SplashScreenSettings>();
 
             // LoadPluginSettings returns null if not saved data is available.
             if (savedSettings != null)
@@ -84,8 +81,8 @@ namespace SplashScreen
                 Settings = new SplashScreenSettings();
             }
 
-            this.pluginUserDataPath = pluginUserDataPath;
-            this.playniteApi = playniteApi;
+            this._pluginUserDataPath = pluginUserDataPath;
+            this._playniteApi = playniteApi;
             SetGlobalSplashImagePath();
         }
 
@@ -97,7 +94,7 @@ namespace SplashScreen
                 return;
             }
 
-            var globalSplashImagePath = Path.Combine(pluginUserDataPath, "CustomBackgrounds", Settings.GeneralSplashSettings.CustomBackgroundImage);
+            var globalSplashImagePath = Path.Combine(_pluginUserDataPath, "CustomBackgrounds", Settings.GeneralSplashSettings.CustomBackgroundImage);
             if (FileSystem.FileExists(globalSplashImagePath))
             {
                 Settings.GlobalSplashImagePath = globalSplashImagePath;
@@ -125,7 +122,7 @@ namespace SplashScreen
         {
             // Code executed when user decides to confirm changes made since BeginEdit was called.
             // This method should save settings made to Option1 and Option2.
-            plugin.SavePluginSettings(Settings);
+            _plugin.SavePluginSettings(Settings);
         }
 
         public bool VerifySettings(out List<string> errors)
@@ -141,11 +138,11 @@ namespace SplashScreen
         {
             get => new RelayCommand(() =>
             {
-                var filePath = playniteApi.Dialogs.SelectImagefile();
+                var filePath = _playniteApi.Dialogs.SelectImagefile();
                 if (!filePath.IsNullOrEmpty() && RemoveGlobalImage())
                 {
                     var fileName = Guid.NewGuid() + Path.GetExtension(filePath);
-                    var globalSplashImagePath = Path.Combine(pluginUserDataPath, "CustomBackgrounds", fileName);
+                    var globalSplashImagePath = Path.Combine(_pluginUserDataPath, "CustomBackgrounds", fileName);
                     try
                     {
                         FileSystem.CopyFile(filePath, globalSplashImagePath);
@@ -154,7 +151,7 @@ namespace SplashScreen
                     }
                     catch (Exception e)
                     {
-                        logger.Error(e, $"Error copying global splash image from {filePath} to {globalSplashImagePath}");
+                        _logger.Error(e, $"Error copying global splash image from {filePath} to {globalSplashImagePath}");
                     }
                 }
             });
@@ -175,7 +172,7 @@ namespace SplashScreen
                 return true;
             }
 
-            var globalSplashImagePath = Path.Combine(pluginUserDataPath, "CustomBackgrounds", Settings.GeneralSplashSettings.CustomBackgroundImage);
+            var globalSplashImagePath = Path.Combine(_pluginUserDataPath, "CustomBackgrounds", Settings.GeneralSplashSettings.CustomBackgroundImage);
             FileSystem.DeleteFileSafe(globalSplashImagePath);
 
             Settings.GeneralSplashSettings.CustomBackgroundImage = null;

--- a/source/Generic/SplashScreen/SplashScreenSettingsView.xaml
+++ b/source/Generic/SplashScreen/SplashScreenSettingsView.xaml
@@ -136,14 +136,14 @@
                     <DockPanel Margin="0,10,0,0">
                         <TextBlock Text="{DynamicResource LOCSplashScreen_SettingSpinnerDashLengthLabel}"
                                    DockPanel.Dock="Left" VerticalAlignment="Center" />
-                        <Slider x:Name="SettingsDashLengthSlider" DockPanel.Dock="Left" Width="220" Minimum="0.5" Maximum="24.0" TickFrequency="0.5" IsSnapToTickEnabled="True"
+                        <Slider x:Name="SettingsDashLengthSlider" DockPanel.Dock="Left" Width="220" Minimum="1" Maximum="100" TickFrequency="1" IsSnapToTickEnabled="True"
                                 Value="{Binding Settings.GeneralSplashSettings.LoadingSpinnerDashLength}" Margin="10,0,0,0" />
-                        <TextBlock Text="{Binding Settings.GeneralSplashSettings.LoadingSpinnerDashLength, StringFormat=F1}" Margin="10,0,0,0" VerticalAlignment="Center" />
+                        <TextBlock Text="{Binding Settings.GeneralSplashSettings.LoadingSpinnerDashLength, StringFormat=F0}" Margin="10,0,0,0" VerticalAlignment="Center" />
                     </DockPanel>
                     <DockPanel Margin="0,10,0,0">
                         <TextBlock Text="{DynamicResource LOCSplashScreen_SettingSpinnerDashCountLabel}"
                                    DockPanel.Dock="Left" VerticalAlignment="Center" />
-                        <Slider x:Name="SettingsDashCountSlider" DockPanel.Dock="Left" Width="220" Minimum="2" Maximum="80" TickFrequency="1" IsSnapToTickEnabled="True"
+                        <Slider x:Name="SettingsDashCountSlider" DockPanel.Dock="Left" Width="220" Minimum="1" Maximum="80" TickFrequency="1" IsSnapToTickEnabled="True"
                             Value="{Binding Settings.GeneralSplashSettings.LoadingSpinnerDashCount}" Margin="10,0,0,0" />
                         <TextBlock Text="{Binding Settings.GeneralSplashSettings.LoadingSpinnerDashCount}" Margin="10,0,0,0" VerticalAlignment="Center" />
                     </DockPanel>

--- a/source/Generic/SplashScreen/SplashScreenSettingsView.xaml
+++ b/source/Generic/SplashScreen/SplashScreenSettingsView.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:pcmd="clr-namespace:PluginsCommon.Commands"
+             xmlns:splashviews="clr-namespace:SplashScreen.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              mc:Ignorable="d"
              d:DesignHeight="700" d:DesignWidth="600">
@@ -81,6 +82,92 @@
                                   SelectedValuePath="Key" Margin="10,0,0,0" />
                     </DockPanel>
                 </StackPanel>
+
+                <CheckBox Name="ShowLoadingSpinner"
+                          IsChecked="{Binding Settings.GeneralSplashSettings.EnableLoadingSpinner}"
+                          Content="{DynamicResource LOCSplashScreen_SettingShowLoadingSpinnerLabel}" Margin="0,10,0,0" />
+                <StackPanel Margin="40,0,0,0" IsEnabled="{Binding ElementName=ShowLoadingSpinner, Path=IsChecked}">
+                    <TextBlock Text="{DynamicResource LOCSplashScreen_SettingSpinnerPreviewLabel}" Margin="0,10,0,4" />
+                    <DockPanel Margin="0,0,0,8">
+                        <TextBlock Text="{DynamicResource LOCSplashScreen_SettingSpinnerPreviewBackgroundLabel}" DockPanel.Dock="Left" VerticalAlignment="Center" />
+                        <Slider x:Name="SettingsPreviewBgSlider" DockPanel.Dock="Left" Width="120" Minimum="0.0" Maximum="1.0" TickFrequency="0.05" IsSnapToTickEnabled="True"
+                                Value="0.5" Margin="10,0,0,0" />
+                        <TextBlock Text="{Binding ElementName=SettingsPreviewBgSlider, Path=Value, StringFormat=F2}" Margin="10,0,0,0" VerticalAlignment="Center" />
+                    </DockPanel>
+                    <splashviews:SpinnerPreviewControl
+                        PreviewBackgroundLevel="{Binding ElementName=SettingsPreviewBgSlider, Path=Value}"
+                        SpinnerSize="{Binding ElementName=SettingsSizeSlider, Path=Value}"
+                        SpinnerOpacity="{Binding ElementName=SettingsOpacitySlider, Path=Value}"
+                        SpinnerThickness="{Binding ElementName=SettingsThicknessSlider, Path=Value}"
+                        SpinnerDashLength="{Binding ElementName=SettingsDashLengthSlider, Path=Value}"
+                        SpinnerDashCount="{Binding ElementName=SettingsDashCountSlider, Path=Value}"
+                        RoundedDashes="{Binding ElementName=SettingsRoundedDashesCb, Path=IsChecked}"
+                        RotationSeconds="{Binding ElementName=SettingsSpeedSlider, Path=Value}"
+                        AutoSpeed="{Binding ElementName=SettingsAutoSpeedCb, Path=IsChecked}"
+                        Margin="0,0,0,6" />
+                    <DockPanel Margin="0,10,0,0">
+                        <TextBlock Text="{DynamicResource LOCSplashScreen_SettingSpinnerSizeLabel}"
+                                   DockPanel.Dock="Left" VerticalAlignment="Center" />
+                        <Slider x:Name="SettingsSizeSlider" DockPanel.Dock="Left" Width="220" Minimum="16" Maximum="96" TickFrequency="2" IsSnapToTickEnabled="True"
+                                Value="{Binding Settings.GeneralSplashSettings.LoadingSpinnerSize}" Margin="10,0,0,0" />
+                        <TextBlock Text="{Binding Settings.GeneralSplashSettings.LoadingSpinnerSize}" Margin="10,0,0,0" VerticalAlignment="Center" />
+                    </DockPanel>
+                    <DockPanel Margin="0,10,0,0">
+                        <TextBlock Text="{DynamicResource LOCSplashScreen_SettingSpinnerOpacityLabel}"
+                                   DockPanel.Dock="Left" VerticalAlignment="Center" />
+                        <Slider x:Name="SettingsOpacitySlider" DockPanel.Dock="Left" Width="220" Minimum="0.20" Maximum="1.0" TickFrequency="0.05" IsSnapToTickEnabled="True"
+                                Value="{Binding Settings.GeneralSplashSettings.LoadingSpinnerOpacity}" Margin="10,0,0,0" />
+                        <TextBlock Text="{Binding Settings.GeneralSplashSettings.LoadingSpinnerOpacity, StringFormat=F2}" Margin="10,0,0,0" VerticalAlignment="Center" />
+                    </DockPanel>
+                    <DockPanel Margin="0,10,0,0">
+                        <TextBlock Text="{DynamicResource LOCSplashScreen_SettingSpinnerSpeedLabel}"
+                                   DockPanel.Dock="Left" VerticalAlignment="Center" />
+                        <Slider x:Name="SettingsSpeedSlider" DockPanel.Dock="Left" Width="220" Minimum="0.25" Maximum="8.0" TickFrequency="0.25" IsSnapToTickEnabled="True"
+                                Value="{Binding Settings.GeneralSplashSettings.LoadingSpinnerRotationSeconds}" Margin="10,0,0,0" />
+                        <TextBlock Text="{Binding Settings.GeneralSplashSettings.LoadingSpinnerRotationSeconds, StringFormat=F2}" Margin="10,0,0,0" VerticalAlignment="Center" />
+                    </DockPanel>
+                    <DockPanel Margin="0,10,0,0">
+                        <TextBlock Text="{DynamicResource LOCSplashScreen_SettingSpinnerThicknessLabel}"
+                                   DockPanel.Dock="Left" VerticalAlignment="Center" />
+                        <Slider x:Name="SettingsThicknessSlider" DockPanel.Dock="Left" Width="220" Minimum="0.5" Maximum="8.0" TickFrequency="0.25" IsSnapToTickEnabled="True"
+                                Value="{Binding Settings.GeneralSplashSettings.LoadingSpinnerThickness}" Margin="10,0,0,0" />
+                        <TextBlock Text="{Binding Settings.GeneralSplashSettings.LoadingSpinnerThickness, StringFormat=F2}" Margin="10,0,0,0" VerticalAlignment="Center" />
+                    </DockPanel>
+                    <DockPanel Margin="0,10,0,0">
+                        <TextBlock Text="{DynamicResource LOCSplashScreen_SettingSpinnerDashLengthLabel}"
+                                   DockPanel.Dock="Left" VerticalAlignment="Center" />
+                        <Slider x:Name="SettingsDashLengthSlider" DockPanel.Dock="Left" Width="220" Minimum="0.5" Maximum="24.0" TickFrequency="0.5" IsSnapToTickEnabled="True"
+                                Value="{Binding Settings.GeneralSplashSettings.LoadingSpinnerDashLength}" Margin="10,0,0,0" />
+                        <TextBlock Text="{Binding Settings.GeneralSplashSettings.LoadingSpinnerDashLength, StringFormat=F1}" Margin="10,0,0,0" VerticalAlignment="Center" />
+                    </DockPanel>
+                    <DockPanel Margin="0,10,0,0">
+                        <TextBlock Text="{DynamicResource LOCSplashScreen_SettingSpinnerDashCountLabel}"
+                                   DockPanel.Dock="Left" VerticalAlignment="Center" />
+                        <Slider x:Name="SettingsDashCountSlider" DockPanel.Dock="Left" Width="220" Minimum="2" Maximum="80" TickFrequency="1" IsSnapToTickEnabled="True"
+                            Value="{Binding Settings.GeneralSplashSettings.LoadingSpinnerDashCount}" Margin="10,0,0,0" />
+                        <TextBlock Text="{Binding Settings.GeneralSplashSettings.LoadingSpinnerDashCount}" Margin="10,0,0,0" VerticalAlignment="Center" />
+                    </DockPanel>
+                    <CheckBox x:Name="SettingsRoundedDashesCb" IsChecked="{Binding Settings.GeneralSplashSettings.LoadingSpinnerRoundedDashes}"
+                              Content="{DynamicResource LOCSplashScreen_SettingSpinnerRoundedDashesLabel}" Margin="0,10,0,0" />
+                    <CheckBox x:Name="SettingsAutoSpeedCb" IsChecked="{Binding Settings.GeneralSplashSettings.EnableLoadingSpinnerAutoSpeed}"
+                              Content="{DynamicResource LOCSplashScreen_SettingSpinnerAutoSpeedLabel}" Margin="0,10,0,0" />
+                </StackPanel>
+
+                <DockPanel Margin="0,20,0,0">
+                    <TextBlock Text="{DynamicResource LOCSplashScreen_SettingSafeAreaPaddingLabel}"
+                               DockPanel.Dock="Left" VerticalAlignment="Center" />
+                    <Slider DockPanel.Dock="Left" Width="220" Minimum="0" Maximum="150" TickFrequency="5" IsSnapToTickEnabled="True"
+                            Value="{Binding Settings.GeneralSplashSettings.SafeAreaPadding}" Margin="10,0,0,0" />
+                    <TextBlock Text="{Binding Settings.GeneralSplashSettings.SafeAreaPadding}" Margin="10,0,0,0" VerticalAlignment="Center" />
+                </DockPanel>
+
+                <DockPanel Margin="0,10,0,0">
+                    <TextBlock Text="{DynamicResource LOCSplashScreen_SettingBackgroundImageOpacityLabel}"
+                               DockPanel.Dock="Left" VerticalAlignment="Center" />
+                    <Slider DockPanel.Dock="Left" Width="220" Minimum="0.0" Maximum="1.0" TickFrequency="0.05" IsSnapToTickEnabled="True"
+                            Value="{Binding Settings.GeneralSplashSettings.BackgroundImageOpacity}" Margin="10,0,0,0" />
+                    <TextBlock Text="{Binding Settings.GeneralSplashSettings.BackgroundImageOpacity, StringFormat=F2}" Margin="10,0,0,0" VerticalAlignment="Center" />
+                </DockPanel>
                 
                 <CheckBox x:Name="CbGlobalSplash" Content="{DynamicResource LOCSplashScreen_SettingUseGlobalSplashImage}"
                       IsChecked="{Binding Settings.GeneralSplashSettings.EnableCustomBackgroundImage}"

--- a/source/Generic/SplashScreen/ViewModels/GameSettingsWindowViewModel.cs
+++ b/source/Generic/SplashScreen/ViewModels/GameSettingsWindowViewModel.cs
@@ -7,32 +7,29 @@ using SplashScreen.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace SplashScreen.ViewModels
 {
     public class GameSettingsWindowViewModel : ObservableObject
     {
-        private static readonly ILogger logger = LogManager.GetLogger();
-        private readonly IPlayniteAPI playniteApi;
-        private readonly string pluginUserDataPath;
-        private readonly string customBackgroundsDirectory;
-        private readonly string gameSettingsPath;
-        private readonly GeneralSplashSettings globalSettings;
-        private bool saveCustomBackground = false;
-        private bool removeCustomBackground = false;
+        private static readonly ILogger _logger = LogManager.GetLogger();
+        private readonly IPlayniteAPI _playniteApi;
+        private readonly string _pluginUserDataPath;
+        private readonly string _customBackgroundsDirectory;
+        private readonly string _gameSettingsPath;
+        private readonly GeneralSplashSettings _globalSettings;
+        private bool _saveCustomBackground = false;
+        private bool _removeCustomBackground = false;
 
-        private Game game;
-        public Game Game { get => game; set => SetValue(ref game, value); }
+        private Game _game;
+        public Game Game { get => _game; set => SetValue(ref _game, value); }
 
-        private string customBackgroundPath = null;
-        public string CustomBackgroundPath { get => customBackgroundPath; set => SetValue(ref customBackgroundPath, value); }
+        private string _customBackgroundPath = null;
+        public string CustomBackgroundPath { get => _customBackgroundPath; set => SetValue(ref _customBackgroundPath, value); }
 
-        private GameSplashSettings settings = new GameSplashSettings();
-        public GameSplashSettings Settings { get => settings; set => SetValue(ref settings, value); }
+        private GameSplashSettings _settings = new GameSplashSettings();
+        public GameSplashSettings Settings { get => _settings; set => SetValue(ref _settings, value); }
 
         public Dictionary<HorizontalAlignment, string> LogoHorizontalSource { get; set; } = new Dictionary<HorizontalAlignment, string>
         {
@@ -50,19 +47,19 @@ namespace SplashScreen.ViewModels
 
         public GameSettingsWindowViewModel(IPlayniteAPI playniteApi, string pluginUserDataPath, Game game, GeneralSplashSettings globalSettings)
         {
-            this.playniteApi = playniteApi;
-            this.pluginUserDataPath = pluginUserDataPath;
-            this.globalSettings = Serialization.GetClone(globalSettings);
-            customBackgroundsDirectory = Path.Combine(pluginUserDataPath, "CustomBackgrounds");
+            this._playniteApi = playniteApi;
+            this._pluginUserDataPath = pluginUserDataPath;
+            this._globalSettings = Serialization.GetClone(globalSettings);
+            _customBackgroundsDirectory = Path.Combine(pluginUserDataPath, "CustomBackgrounds");
             Game = game;
 
-            gameSettingsPath = Path.Combine(pluginUserDataPath, $"{game.Id}.json");
-            if (FileSystem.FileExists(gameSettingsPath))
+            _gameSettingsPath = Path.Combine(pluginUserDataPath, $"{game.Id}.json");
+            if (FileSystem.FileExists(_gameSettingsPath))
             {
-                Settings = Serialization.FromJsonFile<GameSplashSettings>(gameSettingsPath);
+                Settings = Serialization.FromJsonFile<GameSplashSettings>(_gameSettingsPath);
                 if (!Settings.GeneralSplashSettings.CustomBackgroundImage.IsNullOrEmpty())
                 {
-                    CustomBackgroundPath = Path.Combine(customBackgroundsDirectory, Settings.GeneralSplashSettings.CustomBackgroundImage);
+                    CustomBackgroundPath = Path.Combine(_customBackgroundsDirectory, Settings.GeneralSplashSettings.CustomBackgroundImage);
                 }
             }
 
@@ -76,7 +73,7 @@ namespace SplashScreen.ViewModels
                 return;
             }
 
-            var backgroundPath = Path.Combine(customBackgroundsDirectory, Settings.GeneralSplashSettings.CustomBackgroundImage);
+            var backgroundPath = Path.Combine(_customBackgroundsDirectory, Settings.GeneralSplashSettings.CustomBackgroundImage);
             if (FileSystem.FileExists(backgroundPath))
             {
                 FileSystem.DeleteFileSafe(backgroundPath);
@@ -87,17 +84,17 @@ namespace SplashScreen.ViewModels
 
         private void SaveGameSettings()
         {
-            SplashSettingsSyncHelper.ApplyGlobalIndicatorSettings(Settings.GeneralSplashSettings, globalSettings);
+            SplashSettingsSyncHelper.ApplyGlobalIndicatorSettings(Settings.GeneralSplashSettings, _globalSettings);
 
-            if (removeCustomBackground)
+            if (_removeCustomBackground)
             {
                 DeleteCurrentGameBackground();
             }
-            else if (saveCustomBackground && !CustomBackgroundPath.IsNullOrEmpty() && FileSystem.FileExists(CustomBackgroundPath))
+            else if (_saveCustomBackground && !CustomBackgroundPath.IsNullOrEmpty() && FileSystem.FileExists(CustomBackgroundPath))
             {
                 DeleteCurrentGameBackground();
                 var fileName = Guid.NewGuid() + Path.GetExtension(CustomBackgroundPath);
-                var customBackgroundImagePathTarget = Path.Combine(customBackgroundsDirectory, fileName);
+                var customBackgroundImagePathTarget = Path.Combine(_customBackgroundsDirectory, fileName);
                 try
                 {
                     FileSystem.CopyFile(CustomBackgroundPath, customBackgroundImagePathTarget);
@@ -105,20 +102,20 @@ namespace SplashScreen.ViewModels
                 }
                 catch (Exception e)
                 {
-                    logger.Error(e, $"Error copying game custom background image from {CustomBackgroundPath} to {customBackgroundImagePathTarget}");
+                    _logger.Error(e, $"Error copying game custom background image from {CustomBackgroundPath} to {customBackgroundImagePathTarget}");
                 }
             }
 
-            FileSystem.WriteStringToFile(gameSettingsPath, Serialization.ToJson(Settings));
-            playniteApi.Dialogs.ShowMessage(ResourceProvider.GetString("LOCSplashScreen_GameSettingsWindowSettingsSavedLabel"), "Splash Screen");
+            FileSystem.WriteStringToFile(_gameSettingsPath, Serialization.ToJson(Settings));
+            _playniteApi.Dialogs.ShowMessage(ResourceProvider.GetString("LOCSplashScreen_GameSettingsWindowSettingsSavedLabel"), "Splash Screen");
         }
 
         public RelayCommand RemoveCustomBackgroundCommand
         {
             get => new RelayCommand(() =>
             {
-                removeCustomBackground = true;
-                saveCustomBackground = false;
+                _removeCustomBackground = true;
+                _saveCustomBackground = false;
                 CustomBackgroundPath = null;
             }, () => CustomBackgroundPath != null);
         }
@@ -135,14 +132,14 @@ namespace SplashScreen.ViewModels
         {
             get => new RelayCommand(() =>
             {
-                var filePath = playniteApi.Dialogs.SelectImagefile();
+                var filePath = _playniteApi.Dialogs.SelectImagefile();
                 if (filePath.IsNullOrEmpty() || !FileSystem.FileExists(filePath))
                 {
                     return;
                 }
 
-                removeCustomBackground = false;
-                saveCustomBackground = true;
+                _removeCustomBackground = false;
+                _saveCustomBackground = true;
                 CustomBackgroundPath = filePath;
             });
         }

--- a/source/Generic/SplashScreen/ViewModels/GameSettingsWindowViewModel.cs
+++ b/source/Generic/SplashScreen/ViewModels/GameSettingsWindowViewModel.cs
@@ -2,6 +2,7 @@
 using Playnite.SDK.Data;
 using Playnite.SDK.Models;
 using PluginsCommon;
+using SplashScreen.Helpers;
 using SplashScreen.Models;
 using System;
 using System.Collections.Generic;
@@ -20,6 +21,7 @@ namespace SplashScreen.ViewModels
         private readonly string pluginUserDataPath;
         private readonly string customBackgroundsDirectory;
         private readonly string gameSettingsPath;
+        private readonly GeneralSplashSettings globalSettings;
         private bool saveCustomBackground = false;
         private bool removeCustomBackground = false;
 
@@ -46,10 +48,11 @@ namespace SplashScreen.ViewModels
             { VerticalAlignment.Bottom, ResourceProvider.GetString("LOCSplashScreen_SettingVerticalAlignmentBottomLabel") },
         };
 
-        public GameSettingsWindowViewModel(IPlayniteAPI playniteApi, string pluginUserDataPath, Game game)
+        public GameSettingsWindowViewModel(IPlayniteAPI playniteApi, string pluginUserDataPath, Game game, GeneralSplashSettings globalSettings)
         {
             this.playniteApi = playniteApi;
             this.pluginUserDataPath = pluginUserDataPath;
+            this.globalSettings = Serialization.GetClone(globalSettings);
             customBackgroundsDirectory = Path.Combine(pluginUserDataPath, "CustomBackgrounds");
             Game = game;
 
@@ -62,6 +65,8 @@ namespace SplashScreen.ViewModels
                     CustomBackgroundPath = Path.Combine(customBackgroundsDirectory, Settings.GeneralSplashSettings.CustomBackgroundImage);
                 }
             }
+
+            SplashSettingsSyncHelper.ApplyGlobalIndicatorSettings(Settings.GeneralSplashSettings, globalSettings);
         }
 
         private void DeleteCurrentGameBackground()
@@ -82,6 +87,8 @@ namespace SplashScreen.ViewModels
 
         private void SaveGameSettings()
         {
+            SplashSettingsSyncHelper.ApplyGlobalIndicatorSettings(Settings.GeneralSplashSettings, globalSettings);
+
             if (removeCustomBackground)
             {
                 DeleteCurrentGameBackground();

--- a/source/Generic/SplashScreen/ViewModels/SplashScreenImageViewModel.cs
+++ b/source/Generic/SplashScreen/ViewModels/SplashScreenImageViewModel.cs
@@ -1,46 +1,48 @@
 ﻿using PluginsCommon;
 using SplashScreen.Models;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Media.Imaging;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace SplashScreen.ViewModels
 {
-    public class SplashScreenImageViewModel : ObservableObject
+    public class SplashScreenImageViewModel : INotifyPropertyChanged
     {
-        private string splashImagePath = null;
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private string _splashImagePath = null;
         public string SplashImagePath
         {
-            get => splashImagePath;
+            get => _splashImagePath;
             set
             {
-                splashImagePath = value;
+                _splashImagePath = value;
                 OnPropertyChanged();
             }
         }
 
-        private string logoPath = null;
+        private string _logoPath = null;
         public string LogoPath
         {
-            get => logoPath;
+            get => _logoPath;
             set
             {
-                logoPath = value;
+                _logoPath = value;
                 OnPropertyChanged();
             }
         }
 
-        private GeneralSplashSettings settings;
+        private GeneralSplashSettings _settings;
         public GeneralSplashSettings Settings
         {
-            get => settings;
+            get => _settings;
             set
             {
-                settings = value;
+                _settings = value;
                 OnPropertyChanged();
             }
         }
@@ -48,12 +50,12 @@ namespace SplashScreen.ViewModels
         public SplashScreenImageViewModel(GeneralSplashSettings settings, string splashImagePath, string logoPath)
         {
             Settings = settings;
-            if (!splashImagePath.IsNullOrEmpty() && FileSystem.FileExists(splashImagePath))
+            if (!string.IsNullOrEmpty(splashImagePath) && FileSystem.FileExists(splashImagePath))
             {
                 SplashImagePath = splashImagePath;
             }
 
-            if (!logoPath.IsNullOrEmpty() && FileSystem.FileExists(logoPath))
+            if (!string.IsNullOrEmpty(logoPath) && FileSystem.FileExists(logoPath))
             {
                 LogoPath = logoPath;
             }

--- a/source/Generic/SplashScreen/ViewModels/VideoManagerViewModel.cs
+++ b/source/Generic/SplashScreen/ViewModels/VideoManagerViewModel.cs
@@ -6,10 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Data;
 
 namespace SplashScreen.ViewModels
@@ -25,14 +22,14 @@ namespace SplashScreen.ViewModels
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
         
-        private IPlayniteAPI PlayniteApi;
-        private ICollectionView videoItemsCollection;
+        private IPlayniteAPI _playniteApi;
+        private ICollectionView _videoItemsCollection;
         public ICollectionView VideoItemsCollection
         {
-            get => videoItemsCollection;
+            get => _videoItemsCollection;
             set
             {
-                videoItemsCollection = value;
+                _videoItemsCollection = value;
                 OnPropertyChanged();
             }
         }
@@ -46,13 +43,13 @@ namespace SplashScreen.ViewModels
             }
         }
 
-        private string searchString = string.Empty;
+        private string _searchString = string.Empty;
         public string SearchString
         {
-            get { return searchString; }
+            get { return _searchString; }
             set
             {
-                searchString = value;
+                _searchString = value;
                 OnPropertyChanged();
                 VideoItemsCollection.Refresh();
             }
@@ -70,25 +67,25 @@ namespace SplashScreen.ViewModels
             }
         }
 
-        private SourceCollection selectedSourceItem;
+        private SourceCollection _selectedSourceItem;
         public SourceCollection SelectedSourceItem
         {
-            get { return selectedSourceItem; }
+            get { return _selectedSourceItem; }
             set
             {
-                selectedSourceItem = value;
+                _selectedSourceItem = value;
                 VideoItemsCollection.Refresh();
             }
         }
 
-        private VideoManagerItem selectedItem;
+        private VideoManagerItem _selectedItem;
         public VideoManagerItem SelectedItem
         {
-            get { return selectedItem; }
+            get { return _selectedItem; }
             set
             {
-                selectedItem = value;
-                if (selectedItem != null)
+                _selectedItem = value;
+                if (_selectedItem != null)
                 {
                     VideoSource = new Uri(SelectedItem.VideoPath);
                 }
@@ -96,27 +93,27 @@ namespace SplashScreen.ViewModels
             }
         }
 
-        private bool AddButtonIsEnabled = false;
-        private bool RemoveButtonIsEnabled = false;
+        private bool _addButtonIsEnabled = false;
+        private bool _removeButtonIsEnabled = false;
 
         private void SetButtonsStatuses()
         {
             if (SelectedItem == null)
             {
-                AddButtonIsEnabled = false;
-                RemoveButtonIsEnabled = false;
+                _addButtonIsEnabled = false;
+                _removeButtonIsEnabled = false;
                 return;
             }
             
             if (FileSystem.FileExists(SelectedItem.VideoPath))
             {
-                RemoveButtonIsEnabled = true;
+                _removeButtonIsEnabled = true;
             }
             else
             {
-                RemoveButtonIsEnabled = false;
+                _removeButtonIsEnabled = false;
             }
-            AddButtonIsEnabled = true;
+            _addButtonIsEnabled = true;
         }
 
         public RelayCommand<VideoManagerItem> AddVideoCommand
@@ -124,14 +121,14 @@ namespace SplashScreen.ViewModels
             get => new RelayCommand<VideoManagerItem>((item) =>
             {
                 AddVideo(item);
-            }, (item) => AddButtonIsEnabled);
+            }, (item) => _addButtonIsEnabled);
         }
 
         private bool AddVideo(VideoManagerItem videoManagerItem)
         {
             VideoSource = null;
             var videoDestinationPath = videoManagerItem.VideoPath;
-            var videoSourcePath = PlayniteApi.Dialogs.SelectFile("mp4|*.mp4");
+            var videoSourcePath = _playniteApi.Dialogs.SelectFile("mp4|*.mp4");
             if (string.IsNullOrEmpty(videoSourcePath))
             {
                 return false;
@@ -151,7 +148,7 @@ namespace SplashScreen.ViewModels
 
             FileSystem.CopyFile(videoSourcePath, videoDestinationPath, true);
             VideoSource = new Uri(videoDestinationPath);
-            PlayniteApi.Dialogs.ShowMessage(ResourceProvider.GetString("LOCSplashScreen_IntroVideoAddedMessage"), "Splash Screen");
+            _playniteApi.Dialogs.ShowMessage(ResourceProvider.GetString("LOCSplashScreen_IntroVideoAddedMessage"), "Splash Screen");
             return true;
         }
 
@@ -160,25 +157,25 @@ namespace SplashScreen.ViewModels
             get => new RelayCommand<VideoManagerItem>((item) =>
             {
                 RemoveVideo(item);
-            }, (item) => RemoveButtonIsEnabled);
+            }, (item) => _removeButtonIsEnabled);
         }
 
         private void RemoveVideo(VideoManagerItem videoManagerItem)
         {
             VideoSource = null;
             FileSystem.DeleteFileSafe(videoManagerItem.VideoPath);
-            PlayniteApi.Dialogs.ShowMessage(ResourceProvider.GetString("LOCSplashScreen_IntroVideoRemovedMessage"), "Splash Screen");
+            _playniteApi.Dialogs.ShowMessage(ResourceProvider.GetString("LOCSplashScreen_IntroVideoRemovedMessage"), "Splash Screen");
         }
 
         public VideoManagerViewModel(IPlayniteAPI api)
         {
-            PlayniteApi = api;
+            _playniteApi = api;
 
-            string videoPathTemplate = Path.Combine(PlayniteApi.Paths.ConfigurationPath, "ExtraMetadata", "{0}", "{1}", "VideoIntro.mp4");
-            List<VideoManagerItem> videoItemsCollection = new List<VideoManagerItem>();
+            var videoPathTemplate = Path.Combine(_playniteApi.Paths.ConfigurationPath, "ExtraMetadata", "{0}", "{1}", "VideoIntro.mp4");
+            var videoItemsCollection = new List<VideoManagerItem>();
 
             // Games
-            foreach (Game game in PlayniteApi.MainView.SelectedGames)
+            foreach (var game in _playniteApi.MainView.SelectedGames)
             {
                 var item = new VideoManagerItem
                 {
@@ -190,7 +187,7 @@ namespace SplashScreen.ViewModels
             }
 
             // Sources
-            foreach (GameSource source in PlayniteApi.Database.Sources)
+            foreach (var source in _playniteApi.Database.Sources)
             {
                 var item = new VideoManagerItem
                 {
@@ -202,7 +199,7 @@ namespace SplashScreen.ViewModels
             }
 
             // Sources
-            foreach (Platform platform in PlayniteApi.Database.Platforms)
+            foreach (var platform in _playniteApi.Database.Platforms)
             {
                 var item = new VideoManagerItem
                 {
@@ -243,7 +240,7 @@ namespace SplashScreen.ViewModels
 
         private bool CollectionFilter(object item)
         {
-            VideoManagerItem videoManagerItem = item as VideoManagerItem;
+            var videoManagerItem = item as VideoManagerItem;
             if (videoManagerItem.SourceCollection != SelectedSourceItem)
             {
                 return false;

--- a/source/Generic/SplashScreen/Views/GameSettingsWindow.xaml
+++ b/source/Generic/SplashScreen/Views/GameSettingsWindow.xaml
@@ -90,6 +90,22 @@
                             </DockPanel>
                         </StackPanel>
 
+                              <DockPanel Margin="0,20,0,0">
+                                <TextBlock Text="{DynamicResource LOCSplashScreen_SettingSafeAreaPaddingLabel}"
+                                     DockPanel.Dock="Left" VerticalAlignment="Center" />
+                                <Slider DockPanel.Dock="Left" Width="220" Minimum="0" Maximum="150" TickFrequency="5" IsSnapToTickEnabled="True"
+                                    Value="{Binding Settings.GeneralSplashSettings.SafeAreaPadding}" Margin="10,0,0,0" />
+                                <TextBlock Text="{Binding Settings.GeneralSplashSettings.SafeAreaPadding}" Margin="10,0,0,0" VerticalAlignment="Center" />
+                              </DockPanel>
+
+                              <DockPanel Margin="0,10,0,0">
+                                <TextBlock Text="{DynamicResource LOCSplashScreen_SettingBackgroundImageOpacityLabel}"
+                                   DockPanel.Dock="Left" VerticalAlignment="Center" />
+                                <Slider DockPanel.Dock="Left" Width="220" Minimum="0.0" Maximum="1.0" TickFrequency="0.05" IsSnapToTickEnabled="True"
+                                  Value="{Binding Settings.GeneralSplashSettings.BackgroundImageOpacity}" Margin="10,0,0,0" />
+                                <TextBlock Text="{Binding Settings.GeneralSplashSettings.BackgroundImageOpacity, StringFormat=F2}" Margin="10,0,0,0" VerticalAlignment="Center" />
+                              </DockPanel>
+
                         <CheckBox x:Name="CbGlobalSplash" Content="{DynamicResource LOCSplashScreen_GameSettingsWindowUseCustomBackgroundLabel}"
                       IsChecked="{Binding Settings.GeneralSplashSettings.EnableCustomBackgroundImage}"
                       Margin="0,20,0,0" />

--- a/source/Generic/SplashScreen/Views/SpinnerPreviewControl.xaml
+++ b/source/Generic/SplashScreen/Views/SpinnerPreviewControl.xaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="SplashScreen.Views.SpinnerPreviewControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignWidth="120" d:DesignHeight="120">
+    <Border x:Name="PreviewContainer" Background="#FF808080" CornerRadius="4" BorderBrush="#FF555555" BorderThickness="1"
+            Width="120" Height="120" HorizontalAlignment="Left">
+        <Path x:Name="PreviewPath"
+             Width="{Binding SpinnerSize, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+             Height="{Binding SpinnerSize, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+             Stroke="#FFFFFFFF"
+             StrokeThickness="{Binding SpinnerThickness, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+             Opacity="{Binding SpinnerOpacity, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+             Stretch="None"
+             HorizontalAlignment="Center"
+             VerticalAlignment="Center"
+             RenderTransformOrigin="0.5,0.5">
+            <Path.Effect>
+                <DropShadowEffect Direction="0" Color="#FF000000" ShadowDepth="0" BlurRadius="20"/>
+            </Path.Effect>
+            <Path.RenderTransform>
+                <RotateTransform />
+            </Path.RenderTransform>
+        </Path>
+    </Border>
+</UserControl>

--- a/source/Generic/SplashScreen/Views/SpinnerPreviewControl.xaml.cs
+++ b/source/Generic/SplashScreen/Views/SpinnerPreviewControl.xaml.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Shapes;
+using SplashScreen.Helpers;
+
+namespace SplashScreen.Views
+{
+    public partial class SpinnerPreviewControl : UserControl
+    {
+        public static readonly DependencyProperty SpinnerSizeProperty =
+            DependencyProperty.Register(nameof(SpinnerSize), typeof(double), typeof(SpinnerPreviewControl),
+                new PropertyMetadata(50.0, OnAnimationPropertyChanged));
+
+        public static readonly DependencyProperty SpinnerOpacityProperty =
+            DependencyProperty.Register(nameof(SpinnerOpacity), typeof(double), typeof(SpinnerPreviewControl),
+                new PropertyMetadata(0.85));
+
+        public static readonly DependencyProperty PreviewBackgroundLevelProperty =
+            DependencyProperty.Register(nameof(PreviewBackgroundLevel), typeof(double), typeof(SpinnerPreviewControl),
+                new PropertyMetadata(0.5, OnAppearancePropertyChanged));
+
+        public static readonly DependencyProperty SpinnerThicknessProperty =
+            DependencyProperty.Register(nameof(SpinnerThickness), typeof(double), typeof(SpinnerPreviewControl),
+                new PropertyMetadata(2.0, OnAppearancePropertyChanged));
+
+        public static readonly DependencyProperty SpinnerDashLengthProperty =
+            DependencyProperty.Register(nameof(SpinnerDashLength), typeof(double), typeof(SpinnerPreviewControl),
+                new PropertyMetadata(4.0, OnAppearancePropertyChanged));
+
+        public static readonly DependencyProperty SpinnerDashCountProperty =
+            DependencyProperty.Register(nameof(SpinnerDashCount), typeof(int), typeof(SpinnerPreviewControl),
+                new PropertyMetadata(16, OnAppearancePropertyChanged));
+
+        public static readonly DependencyProperty RoundedDashesProperty =
+            DependencyProperty.Register(nameof(RoundedDashes), typeof(bool), typeof(SpinnerPreviewControl),
+                new PropertyMetadata(false, OnAppearancePropertyChanged));
+
+        public static readonly DependencyProperty RotationSecondsProperty =
+            DependencyProperty.Register(nameof(RotationSeconds), typeof(double), typeof(SpinnerPreviewControl),
+                new PropertyMetadata(3.0, OnAnimationPropertyChanged));
+
+        public static readonly DependencyProperty AutoSpeedProperty =
+            DependencyProperty.Register(nameof(AutoSpeed), typeof(bool), typeof(SpinnerPreviewControl),
+                new PropertyMetadata(true, OnAnimationPropertyChanged));
+
+        public double SpinnerSize
+        {
+            get => (double)GetValue(SpinnerSizeProperty);
+            set => SetValue(SpinnerSizeProperty, value);
+        }
+
+        public double SpinnerOpacity
+        {
+            get => (double)GetValue(SpinnerOpacityProperty);
+            set => SetValue(SpinnerOpacityProperty, value);
+        }
+
+        public double PreviewBackgroundLevel
+        {
+            get => (double)GetValue(PreviewBackgroundLevelProperty);
+            set => SetValue(PreviewBackgroundLevelProperty, value);
+        }
+
+        public double SpinnerThickness
+        {
+            get => (double)GetValue(SpinnerThicknessProperty);
+            set => SetValue(SpinnerThicknessProperty, value);
+        }
+
+        public double SpinnerDashLength
+        {
+            get => (double)GetValue(SpinnerDashLengthProperty);
+            set => SetValue(SpinnerDashLengthProperty, value);
+        }
+
+        public int SpinnerDashCount
+        {
+            get => (int)GetValue(SpinnerDashCountProperty);
+            set => SetValue(SpinnerDashCountProperty, value);
+        }
+
+        public bool RoundedDashes
+        {
+            get => (bool)GetValue(RoundedDashesProperty);
+            set => SetValue(RoundedDashesProperty, value);
+        }
+
+        public double RotationSeconds
+        {
+            get => (double)GetValue(RotationSecondsProperty);
+            set => SetValue(RotationSecondsProperty, value);
+        }
+
+        public bool AutoSpeed
+        {
+            get => (bool)GetValue(AutoSpeedProperty);
+            set => SetValue(AutoSpeedProperty, value);
+        }
+
+        private bool _isLoaded;
+
+        public SpinnerPreviewControl()
+        {
+            InitializeComponent();
+            Loaded += (s, e) =>
+            {
+                _isLoaded = true;
+                ApplyAppearance();
+                ApplyAnimation();
+            };
+        }
+
+        private static void OnAnimationPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is SpinnerPreviewControl control && control._isLoaded)
+            {
+                control.ApplyAnimation();
+            }
+        }
+
+        private static void OnAppearancePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is SpinnerPreviewControl control && control._isLoaded)
+            {
+                control.ApplyAppearance();
+            }
+        }
+
+        private void ApplyAppearance()
+        {
+            if (PreviewPath == null)
+            {
+                return;
+            }
+
+            var previewLevel = PreviewBackgroundLevel;
+            if (previewLevel < 0.0)
+            {
+                previewLevel = 0.0;
+            }
+            else if (previewLevel > 1.0)
+            {
+                previewLevel = 1.0;
+            }
+
+            var channel = (byte)(previewLevel * 255.0);
+            if (PreviewContainer != null)
+            {
+                PreviewContainer.Background = new SolidColorBrush(Color.FromRgb(channel, channel, channel));
+            }
+
+            var thickness = SpinnerThickness;
+            if (thickness < 0.5)
+            {
+                thickness = 0.5;
+            }
+
+            var dashLengthPx = SpinnerDashLength;
+            if (dashLengthPx < 0.5)
+            {
+                dashLengthPx = 0.5;
+            }
+
+            var dashCount = SpinnerDashCount;
+            if (dashCount < 2)
+            {
+                dashCount = 2;
+            }
+
+            var spinnerSize = SpinnerSize;
+            if (spinnerSize < 4)
+            {
+                spinnerSize = 4;
+            }
+
+            var roundedDashes = RoundedDashes;
+            PreviewPath.StrokeThickness = thickness;
+            PreviewPath.StrokeDashArray = null;
+            PreviewPath.StrokeDashOffset = 0;
+            PreviewPath.StrokeDashCap = PenLineCap.Flat;
+            PreviewPath.StrokeStartLineCap = roundedDashes ? PenLineCap.Round : PenLineCap.Flat;
+            PreviewPath.StrokeEndLineCap = roundedDashes ? PenLineCap.Round : PenLineCap.Flat;
+            PreviewPath.Data = SpinnerGeometryBuilder.BuildDashGeometry(spinnerSize, thickness, dashLengthPx, dashCount, roundedDashes);
+        }
+
+        private void ApplyAnimation()
+        {
+            if (PreviewPath == null)
+            {
+                return;
+            }
+
+            ApplyAppearance();
+
+            if (!(PreviewPath.RenderTransform is RotateTransform rotateTransform))
+            {
+                rotateTransform = new RotateTransform();
+                PreviewPath.RenderTransform = rotateTransform;
+            }
+
+            rotateTransform.BeginAnimation(RotateTransform.AngleProperty, null);
+
+            var baseSeconds = RotationSeconds;
+            if (baseSeconds <= 0)
+            {
+                baseSeconds = 3.0;
+            }
+
+            var durationSeconds = baseSeconds;
+            if (AutoSpeed)
+            {
+                var normalizedSize = SpinnerSize / 50.0;
+                if (normalizedSize < 0.4)
+                {
+                    normalizedSize = 0.4;
+                }
+
+                durationSeconds = baseSeconds * normalizedSize;
+            }
+
+            if (durationSeconds < 0.25)
+            {
+                durationSeconds = 0.25;
+            }
+
+            if (durationSeconds > 20.0)
+            {
+                durationSeconds = 20.0;
+            }
+
+            var animation = new DoubleAnimation
+            {
+                From = 0,
+                To = 360,
+                Duration = TimeSpan.FromSeconds(durationSeconds),
+                RepeatBehavior = RepeatBehavior.Forever
+            };
+
+            rotateTransform.BeginAnimation(RotateTransform.AngleProperty, animation);
+        }
+
+    }
+}

--- a/source/Generic/SplashScreen/Views/SpinnerPreviewControl.xaml.cs
+++ b/source/Generic/SplashScreen/Views/SpinnerPreviewControl.xaml.cs
@@ -28,7 +28,7 @@ namespace SplashScreen.Views
 
         public static readonly DependencyProperty SpinnerDashLengthProperty =
             DependencyProperty.Register(nameof(SpinnerDashLength), typeof(double), typeof(SpinnerPreviewControl),
-                new PropertyMetadata(4.0, OnAppearancePropertyChanged));
+                new PropertyMetadata(70.0, OnAppearancePropertyChanged));
 
         public static readonly DependencyProperty SpinnerDashCountProperty =
             DependencyProperty.Register(nameof(SpinnerDashCount), typeof(int), typeof(SpinnerPreviewControl),
@@ -152,38 +152,13 @@ namespace SplashScreen.Views
                 PreviewContainer.Background = new SolidColorBrush(Color.FromRgb(channel, channel, channel));
             }
 
-            var thickness = SpinnerThickness;
-            if (thickness < 0.5)
-            {
-                thickness = 0.5;
-            }
-
-            var dashLengthPx = SpinnerDashLength;
-            if (dashLengthPx < 0.5)
-            {
-                dashLengthPx = 0.5;
-            }
-
-            var dashCount = SpinnerDashCount;
-            if (dashCount < 2)
-            {
-                dashCount = 2;
-            }
-
-            var spinnerSize = SpinnerSize;
-            if (spinnerSize < 4)
-            {
-                spinnerSize = 4;
-            }
-
-            var roundedDashes = RoundedDashes;
-            PreviewPath.StrokeThickness = thickness;
-            PreviewPath.StrokeDashArray = null;
-            PreviewPath.StrokeDashOffset = 0;
-            PreviewPath.StrokeDashCap = PenLineCap.Flat;
-            PreviewPath.StrokeStartLineCap = roundedDashes ? PenLineCap.Round : PenLineCap.Flat;
-            PreviewPath.StrokeEndLineCap = roundedDashes ? PenLineCap.Round : PenLineCap.Flat;
-            PreviewPath.Data = SpinnerGeometryBuilder.BuildDashGeometry(spinnerSize, thickness, dashLengthPx, dashCount, roundedDashes);
+            SpinnerRenderHelper.ApplySpinnerAppearance(
+                PreviewPath,
+                SpinnerSize,
+                SpinnerThickness,
+                SpinnerDashLength,
+                SpinnerDashCount,
+                RoundedDashes);
         }
 
         private void ApplyAnimation()
@@ -202,34 +177,7 @@ namespace SplashScreen.Views
             }
 
             rotateTransform.BeginAnimation(RotateTransform.AngleProperty, null);
-
-            var baseSeconds = RotationSeconds;
-            if (baseSeconds <= 0)
-            {
-                baseSeconds = 3.0;
-            }
-
-            var durationSeconds = baseSeconds;
-            if (AutoSpeed)
-            {
-                var normalizedSize = SpinnerSize / 50.0;
-                if (normalizedSize < 0.4)
-                {
-                    normalizedSize = 0.4;
-                }
-
-                durationSeconds = baseSeconds * normalizedSize;
-            }
-
-            if (durationSeconds < 0.25)
-            {
-                durationSeconds = 0.25;
-            }
-
-            if (durationSeconds > 20.0)
-            {
-                durationSeconds = 20.0;
-            }
+            var durationSeconds = SpinnerRenderHelper.CalculateRotationDurationSeconds(RotationSeconds, AutoSpeed, SpinnerSize);
 
             var animation = new DoubleAnimation
             {

--- a/source/Generic/SplashScreen/Views/SpinnerPreviewControl.xaml.cs
+++ b/source/Generic/SplashScreen/Views/SpinnerPreviewControl.xaml.cs
@@ -3,7 +3,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
-using System.Windows.Shapes;
 using SplashScreen.Helpers;
 
 namespace SplashScreen.Views

--- a/source/Generic/SplashScreen/Views/SplashScreenImage.xaml
+++ b/source/Generic/SplashScreen/Views/SplashScreenImage.xaml
@@ -7,13 +7,9 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid Background="Black" Cursor="None">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <Image Name="BackgroundImage" Stretch="UniformToFill"
-               HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="0" Grid.ColumnSpan="3">
+
+         <Image Name="BackgroundImage" Stretch="UniformToFill" Opacity="{Binding Settings.BackgroundImageOpacity}"
+             HorizontalAlignment="Center" VerticalAlignment="Center">
             <Image.Style>
                 <Style TargetType="Image">
                     <Setter Property="Source" Value="{Binding SplashImagePath, Converter={StaticResource ImageStringToImageConverter}}" />
@@ -25,57 +21,87 @@
                 </Style>
             </Image.Style>
         </Image>
-        <Image Name="LogoImage" Stretch="Uniform" VerticalAlignment="{Binding Settings.LogoVerticalAlignment}"
-               HorizontalAlignment="Center" Grid.ColumnSpan="1" Margin="20">
-            <Image.Effect>
-                <DropShadowEffect Direction="0" Color="#FF000000" ShadowDepth="0" BlurRadius="40" />
-            </Image.Effect>
-            <Image.Style>
-                <Style TargetType="Image">
-                    <Setter Property="Source" Value="{x:Null}" />
-                    <Setter Property="Grid.Column" Value="0" />
-                    <Setter Property="Opacity" Value="1.0" />
-                    <Setter Property="Tag" Value="False" />
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding LogoPath, Converter={StaticResource NullToBoolConverter}}" Value="True">
-                            <Setter Property="Source" Value="{Binding LogoPath, Converter={StaticResource ImageStringToImageConverter}}" />
-                            <Setter Property="Tag" Value="True" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding SplashImagePath}" Value="{x:Null}">
-                            <Setter Property="Source" Value="{x:Null}" />
-                            <Setter Property="Tag" Value="False" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding Settings.LogoHorizontalAlignment}" Value="Center">
-                            <Setter Property="Grid.Column" Value="1" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding Settings.LogoHorizontalAlignment}" Value="Right">
-                            <Setter Property="Grid.Column" Value="2" />
-                        </DataTrigger>
-                        <MultiDataTrigger>
-                            <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsVisible}" Value="True" />
-                                <Condition Binding="{Binding Settings.EnableLogoFadeInAnimation}" Value="True" />
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Source, Converter={StaticResource NullToBoolConverter}}" Value="True" />
-                            </MultiDataTrigger.Conditions>
-                            <MultiDataTrigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="0:0:2.5" />
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </MultiDataTrigger.EnterActions>
-                        </MultiDataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Image.Style>
-        </Image>
-        
-        <Border Background="Black" Grid.Column="0" Grid.ColumnSpan="3">
+
+        <Grid Margin="{Binding Settings.SafeAreaPadding, StringFormat={}{0}}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Image Name="LogoImage" Stretch="Uniform" VerticalAlignment="{Binding Settings.LogoVerticalAlignment}"
+                   HorizontalAlignment="Center" Grid.ColumnSpan="1" Margin="20">
+                <Image.Effect>
+                    <DropShadowEffect Direction="0" Color="#FF000000" ShadowDepth="0" BlurRadius="40" />
+                </Image.Effect>
+                <Image.Style>
+                    <Style TargetType="Image">
+                        <Setter Property="Source" Value="{x:Null}" />
+                        <Setter Property="Grid.Column" Value="0" />
+                        <Setter Property="Opacity" Value="1.0" />
+                        <Setter Property="Tag" Value="False" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding LogoPath, Converter={StaticResource NullToBoolConverter}}" Value="True">
+                                <Setter Property="Source" Value="{Binding LogoPath, Converter={StaticResource ImageStringToImageConverter}}" />
+                                <Setter Property="Tag" Value="True" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding SplashImagePath}" Value="{x:Null}">
+                                <Setter Property="Source" Value="{x:Null}" />
+                                <Setter Property="Tag" Value="False" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding Settings.LogoHorizontalAlignment}" Value="Center">
+                                <Setter Property="Grid.Column" Value="1" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding Settings.LogoHorizontalAlignment}" Value="Right">
+                                <Setter Property="Grid.Column" Value="2" />
+                            </DataTrigger>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsVisible}" Value="True" />
+                                    <Condition Binding="{Binding Settings.EnableLogoFadeInAnimation}" Value="True" />
+                                    <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Source, Converter={StaticResource NullToBoolConverter}}" Value="True" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.EnterActions>
+                                    <BeginStoryboard>
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="0:0:2.5" />
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </MultiDataTrigger.EnterActions>
+                            </MultiDataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Image.Style>
+            </Image>
+
+            <Grid Grid.ColumnSpan="3" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,12,12">
+                <Grid.Style>
+                    <Style TargetType="Grid">
+                        <Setter Property="Visibility" Value="Visible" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Settings.EnableLoadingSpinner}" Value="False">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Grid.Style>
+                <Path x:Name="SpinnerPath" Width="{Binding Settings.LoadingSpinnerSize}" Height="{Binding Settings.LoadingSpinnerSize}" Stroke="#FFFFFFFF" StrokeThickness="{Binding Settings.LoadingSpinnerThickness}" Opacity="{Binding Settings.LoadingSpinnerOpacity}" Stretch="None" HorizontalAlignment="Center" VerticalAlignment="Center" RenderTransformOrigin="0.5,0.5">
+                    <Path.Effect>
+                        <DropShadowEffect Direction="0" Color="#FF000000" ShadowDepth="0" BlurRadius="20"/>
+                    </Path.Effect>
+                    <Path.RenderTransform>
+                        <RotateTransform />
+                    </Path.RenderTransform>
+                </Path>
+            </Grid>
+        </Grid>
+
+        <Border Background="Black">
             <Border.Style>
                 <Style TargetType="Border">
                     <Setter Property="Opacity" Value="0.0" />
                     <Style.Triggers>
-                        
+
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsVisible}" Value="True" />
@@ -90,7 +116,7 @@
                                 </BeginStoryboard>
                             </MultiDataTrigger.EnterActions>
                         </MultiDataTrigger>
-                        
+
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsVisible}" Value="True" />
@@ -105,7 +131,7 @@
                                 </BeginStoryboard>
                             </MultiDataTrigger.EnterActions>
                         </MultiDataTrigger>
-                        
+
                     </Style.Triggers>
                 </Style>
             </Border.Style>

--- a/source/Generic/SplashScreen/Views/SplashScreenImage.xaml.cs
+++ b/source/Generic/SplashScreen/Views/SplashScreenImage.xaml.cs
@@ -60,34 +60,10 @@ namespace SplashScreen.Views
             }
 
             rotateTransform.BeginAnimation(RotateTransform.AngleProperty, null);
-
-            var baseSeconds = vm.Settings.LoadingSpinnerRotationSeconds;
-            if (baseSeconds <= 0)
-            {
-                baseSeconds = 3.0;
-            }
-
-            var durationSeconds = baseSeconds;
-            if (vm.Settings.EnableLoadingSpinnerAutoSpeed)
-            {
-                var normalizedSize = vm.Settings.LoadingSpinnerSize / 50.0;
-                if (normalizedSize < 0.4)
-                {
-                    normalizedSize = 0.4;
-                }
-
-                durationSeconds = baseSeconds * normalizedSize;
-            }
-
-            if (durationSeconds < 0.25)
-            {
-                durationSeconds = 0.25;
-            }
-
-            if (durationSeconds > 20.0)
-            {
-                durationSeconds = 20.0;
-            }
+            var durationSeconds = SpinnerRenderHelper.CalculateRotationDurationSeconds(
+                vm.Settings.LoadingSpinnerRotationSeconds,
+                vm.Settings.EnableLoadingSpinnerAutoSpeed,
+                vm.Settings.LoadingSpinnerSize);
 
             var animation = new DoubleAnimation
             {
@@ -102,43 +78,13 @@ namespace SplashScreen.Views
 
         private void ConfigureSpinnerAppearance(Models.GeneralSplashSettings settings)
         {
-            if (SpinnerPath == null)
-            {
-                return;
-            }
-
-            var thickness = settings.LoadingSpinnerThickness;
-            if (thickness < 0.5)
-            {
-                thickness = 0.5;
-            }
-
-            var dashLengthPx = settings.LoadingSpinnerDashLength;
-            if (dashLengthPx < 0.5)
-            {
-                dashLengthPx = 0.5;
-            }
-
-            var dashCount = settings.LoadingSpinnerDashCount;
-            if (dashCount < 2)
-            {
-                dashCount = 2;
-            }
-
-            var spinnerSize = settings.LoadingSpinnerSize;
-            if (spinnerSize < 4)
-            {
-                spinnerSize = 4;
-            }
-
-            var roundedDashes = settings.LoadingSpinnerRoundedDashes;
-            SpinnerPath.StrokeThickness = thickness;
-            SpinnerPath.StrokeDashArray = null;
-            SpinnerPath.StrokeDashOffset = 0;
-            SpinnerPath.StrokeDashCap = PenLineCap.Flat;
-            SpinnerPath.StrokeStartLineCap = roundedDashes ? PenLineCap.Round : PenLineCap.Flat;
-            SpinnerPath.StrokeEndLineCap = roundedDashes ? PenLineCap.Round : PenLineCap.Flat;
-            SpinnerPath.Data = SpinnerGeometryBuilder.BuildDashGeometry(spinnerSize, thickness, dashLengthPx, dashCount, roundedDashes);
+            SpinnerRenderHelper.ApplySpinnerAppearance(
+                SpinnerPath,
+                settings.LoadingSpinnerSize,
+                settings.LoadingSpinnerThickness,
+                settings.LoadingSpinnerDashLength,
+                settings.LoadingSpinnerDashCount,
+                settings.LoadingSpinnerRoundedDashes);
         }
     }
 }

--- a/source/Generic/SplashScreen/Views/SplashScreenImage.xaml.cs
+++ b/source/Generic/SplashScreen/Views/SplashScreenImage.xaml.cs
@@ -1,20 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using System.Windows.Media.Animation;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using System.Windows.Threading;
 using SplashScreen.Helpers;
 using SplashScreen.ViewModels;
 

--- a/source/Generic/SplashScreen/Views/SplashScreenImage.xaml.cs
+++ b/source/Generic/SplashScreen/Views/SplashScreenImage.xaml.cs
@@ -11,9 +11,12 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Media.Animation;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using System.Windows.Threading;
+using SplashScreen.Helpers;
+using SplashScreen.ViewModels;
 
 namespace SplashScreen.Views
 {
@@ -25,6 +28,117 @@ namespace SplashScreen.Views
         public SplashScreenImage()
         {
             InitializeComponent();
+            Loaded += SplashScreenImage_Loaded;
+            DataContextChanged += SplashScreenImage_DataContextChanged;
+        }
+
+        private void SplashScreenImage_Loaded(object sender, RoutedEventArgs e)
+        {
+            ConfigureSpinnerAnimation();
+        }
+
+        private void SplashScreenImage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            ConfigureSpinnerAnimation();
+        }
+
+        private void ConfigureSpinnerAnimation()
+        {
+            if (!(DataContext is SplashScreenImageViewModel vm) || vm.Settings == null)
+            {
+                return;
+            }
+
+            ConfigureSpinnerAppearance(vm.Settings);
+
+            SpinnerPath?.BeginAnimation(UIElement.OpacityProperty, null);
+
+            if (!(SpinnerPath.RenderTransform is RotateTransform rotateTransform))
+            {
+                rotateTransform = new RotateTransform();
+                SpinnerPath.RenderTransform = rotateTransform;
+            }
+
+            rotateTransform.BeginAnimation(RotateTransform.AngleProperty, null);
+
+            var baseSeconds = vm.Settings.LoadingSpinnerRotationSeconds;
+            if (baseSeconds <= 0)
+            {
+                baseSeconds = 3.0;
+            }
+
+            var durationSeconds = baseSeconds;
+            if (vm.Settings.EnableLoadingSpinnerAutoSpeed)
+            {
+                var normalizedSize = vm.Settings.LoadingSpinnerSize / 50.0;
+                if (normalizedSize < 0.4)
+                {
+                    normalizedSize = 0.4;
+                }
+
+                durationSeconds = baseSeconds * normalizedSize;
+            }
+
+            if (durationSeconds < 0.25)
+            {
+                durationSeconds = 0.25;
+            }
+
+            if (durationSeconds > 20.0)
+            {
+                durationSeconds = 20.0;
+            }
+
+            var animation = new DoubleAnimation
+            {
+                From = 0,
+                To = 360,
+                Duration = TimeSpan.FromSeconds(durationSeconds),
+                RepeatBehavior = RepeatBehavior.Forever
+            };
+
+            rotateTransform.BeginAnimation(RotateTransform.AngleProperty, animation);
+        }
+
+        private void ConfigureSpinnerAppearance(Models.GeneralSplashSettings settings)
+        {
+            if (SpinnerPath == null)
+            {
+                return;
+            }
+
+            var thickness = settings.LoadingSpinnerThickness;
+            if (thickness < 0.5)
+            {
+                thickness = 0.5;
+            }
+
+            var dashLengthPx = settings.LoadingSpinnerDashLength;
+            if (dashLengthPx < 0.5)
+            {
+                dashLengthPx = 0.5;
+            }
+
+            var dashCount = settings.LoadingSpinnerDashCount;
+            if (dashCount < 2)
+            {
+                dashCount = 2;
+            }
+
+            var spinnerSize = settings.LoadingSpinnerSize;
+            if (spinnerSize < 4)
+            {
+                spinnerSize = 4;
+            }
+
+            var roundedDashes = settings.LoadingSpinnerRoundedDashes;
+            SpinnerPath.StrokeThickness = thickness;
+            SpinnerPath.StrokeDashArray = null;
+            SpinnerPath.StrokeDashOffset = 0;
+            SpinnerPath.StrokeDashCap = PenLineCap.Flat;
+            SpinnerPath.StrokeStartLineCap = roundedDashes ? PenLineCap.Round : PenLineCap.Flat;
+            SpinnerPath.StrokeEndLineCap = roundedDashes ? PenLineCap.Round : PenLineCap.Flat;
+            SpinnerPath.Data = SpinnerGeometryBuilder.BuildDashGeometry(spinnerSize, thickness, dashLengthPx, dashCount, roundedDashes);
         }
     }
 }


### PR DESCRIPTION
This PR introduces three quality-of-life improvements to the extension to enhance visual feedback and UI readability:

- Customizable Loading Indicator: Added a visual cue for long loading. This ensures the user knows the application is still responsive during extended wait times.
- Background Dimming: This significantly improves the contrast ratio, making logos much easier to read regardless of the wallpaper used.
- Edge Padding: Added consistent spacing to prevent UI elements from touching the screen edges.

Added settings interface:
![20260318-2217-59 2580395](https://github.com/user-attachments/assets/5d5a8342-47b8-491b-aa93-8b52d8ea88e5)

I provided translations only for the labels I introduced, but I’m not proficient in all supported languages, so additional review by native speakers is recommended.

I have verified that:
- [x] These changes work, by building the extension and testing.
- [x] That the changes comply with the [rules](https://github.com/darklinkpower/PlayniteExtensionsCollection#contributing) indicated in the repository.
- [x] Pull request is targeting `master` branch.
