### PR TITLE
Fix JAST USA Library Authentication and Sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ packages/
 # Ignore everything else in release folders
 **/bin/[Rr]elease*/
 /.stfolder/
+.agent/
+~logs/
+~temp/

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,3 @@ packages/
 # Ignore everything else in release folders
 **/bin/[Rr]elease*/
 /.stfolder/
-.agent/
-~logs/
-~temp/

--- a/source/Library/JastUsaLibrary/Features/MetadataProvider/JastUsaLibraryMetadataProvider.cs
+++ b/source/Library/JastUsaLibrary/Features/MetadataProvider/JastUsaLibraryMetadataProvider.cs
@@ -1,4 +1,4 @@
-﻿using Playnite.SDK;
+using Playnite.SDK;
 using Playnite.SDK.Data;
 using Playnite.SDK.Models;
 using PluginsCommon;
@@ -30,7 +30,7 @@ namespace JastUsaLibrary.Features.MetadataProvider
                 return new GameMetadata();
             }
 
-            var url = string.Format(@"https://app.jastusa.com/api/v2/shop/products/{0}?localeCode=en_US", productCode);
+            var url = string.Format(@"https://app.jaststore.com/api/v2/shop/products/{0}?localeCode=en_US", productCode);
             var downloadedString = HttpRequestFactory.GetHttpRequest().WithUrl(url).DownloadString();
             if (!downloadedString.IsSuccess)
             {
@@ -85,7 +85,7 @@ namespace JastUsaLibrary.Features.MetadataProvider
                 metadata.BackgroundImage = new MetadataFile(string.Format(JastUsaWebUrls.JastMediaUrlTemplate, backgroundImage.Path));
             }
 
-            metadata.Links = new List<Link> { new Link("Store", @"https://jastusa.com/games/" + productResponse.Code) };
+            metadata.Links = new List<Link> { new Link("Store", @"https://jaststore.com/games/" + productResponse.Code) };
             var urlAttributes = productResponse.Attributes.Where(x => x.Code.EndsWith("_url") && x.Value.HasItems() &&
                                 x.Value.First().StartsWith("http"));
             if (urlAttributes.HasItems())

--- a/source/Library/JastUsaLibrary/Features/MetadataProvider/JastUsaWebUrls.cs
+++ b/source/Library/JastUsaLibrary/Features/MetadataProvider/JastUsaWebUrls.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,8 +8,8 @@ namespace JastUsaLibrary.Features.MetadataProvider
 {
     internal class JastUsaWebUrls
     {
-        public const string JastBaseAppUrl = @"https://app.jastusa.com";
-        public const string MyAccountPage = "https://jastusa.com/my-account";
-        public const string JastMediaUrlTemplate = @"https://app.jastusa.com/media/image/{0}";
+        public const string JastBaseAppUrl = @"https://app.jaststore.com";
+        public const string MyAccountPage = "https://jaststore.com/my-account";
+        public const string JastMediaUrlTemplate = @"https://app.jaststore.com/media/image/{0}";
     }
 }

--- a/source/Library/JastUsaLibrary/JastUsaLibraryClient.cs
+++ b/source/Library/JastUsaLibrary/JastUsaLibraryClient.cs
@@ -1,4 +1,4 @@
-﻿using Playnite.SDK;
+using Playnite.SDK;
 using PluginsCommon;
 using System;
 using System.Collections.Generic;
@@ -17,7 +17,7 @@ namespace JastUsaLibrary
 
         public override void Open()
         {
-            ProcessStarter.StartUrl(@"https://jastusa.com/");
+            ProcessStarter.StartUrl(@"https://jaststore.com/");
         }
     }
 }

--- a/source/Library/JastUsaLibrary/Services/JastUsaIntegration/Infrastructure/DTOs/GetGamesResponse.cs
+++ b/source/Library/JastUsaLibrary/Services/JastUsaIntegration/Infrastructure/DTOs/GetGamesResponse.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
@@ -170,7 +170,7 @@ namespace JastUsaLibrary.Services.JastUsaIntegration.Infrastructure.DTOs
         Zh_Hant
     };
 
-    public enum TranslationType { GameLinkTranslation };
+    public enum TranslationType { GameLinkTranslation, GameLinkLocale };
 
     public enum GameType { Game };
 
@@ -276,9 +276,12 @@ namespace JastUsaLibrary.Services.JastUsaIntegration.Infrastructure.DTOs
         {
             if (reader.TokenType == JsonToken.Null) return null;
             var value = serializer.Deserialize<string>(reader);
-            if (value == "GameLinkTranslation")
+            switch (value)
             {
-                return TranslationType.GameLinkTranslation;
+                case "GameLinkTranslation":
+                    return TranslationType.GameLinkTranslation;
+                case "GameLinkLocale":
+                    return TranslationType.GameLinkLocale;
             }
             throw new Exception("Cannot unmarshal type EnUsType");
         }
@@ -291,10 +294,14 @@ namespace JastUsaLibrary.Services.JastUsaIntegration.Infrastructure.DTOs
                 return;
             }
             var value = (TranslationType)untypedValue;
-            if (value == TranslationType.GameLinkTranslation)
+            switch (value)
             {
-                serializer.Serialize(writer, "GameLinkTranslation");
-                return;
+                case TranslationType.GameLinkTranslation:
+                    serializer.Serialize(writer, "GameLinkTranslation");
+                    return;
+                case TranslationType.GameLinkLocale:
+                    serializer.Serialize(writer, "GameLinkLocale");
+                    return;
             }
             throw new Exception("Cannot marshal type EnUsType");
         }

--- a/source/Library/JastUsaLibrary/Services/JastUsaIntegration/Infrastructure/External/JastUrls.cs
+++ b/source/Library/JastUsaLibrary/Services/JastUsaIntegration/Infrastructure/External/JastUrls.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -10,7 +10,7 @@ namespace JastUsaLibrary
     {
         public static class Api
         {
-            private const string BaseApiUrl = "https://app.jastusa.com/api/v2/";
+            private const string BaseApiUrl = "https://app.jaststore.com/api/v2/";
             private const string LocaleCode = "en_US";
 
             public static class Authentication

--- a/source/Library/JastUsaLibrary/Services/JastUsaIntegration/Infrastructure/External/JastUsaApiClient.cs
+++ b/source/Library/JastUsaLibrary/Services/JastUsaIntegration/Infrastructure/External/JastUsaApiClient.cs
@@ -1,4 +1,4 @@
-﻿using FlowHttp;
+using FlowHttp;
 using FlowHttp.Constants;
 using JastUsaLibrary.JastUsaIntegration.Domain.Exceptions;
 using JastUsaLibrary.Services.JastUsaIntegration.Domain.ValueObjects;
@@ -92,7 +92,7 @@ namespace JastUsaLibrary.JastUsaIntegration.Infrastructure.External
                 ["Accept-Encoding"] = "utf-8"
             };
 
-            var translationsUrl = string.Format(@"https://app.jastusa.com/api/v2/shop/account/game-translations/{0}", translationId);
+            var translationsUrl = string.Format(@"https://app.jaststore.com/api/v2/shop/account/game-translations/{0}", translationId);
             var request = HttpRequestFactory.GetHttpRequest()
                 .WithUrl(translationsUrl)
                 .WithHeaders(headers);


### PR DESCRIPTION
### Description
This pull request fixes a critical break in the **JAST USA Library** add-on where both authentication and library sync were completely failing following a platform migration by JAST USA.

### Root Cause & Issues Fixed

#### 1. API Domain Migration (Authentication Failure)
JAST USA rebranded and migrated their platform from `jastusa.com` to `jaststore.com`. The old API backend at `app.jastusa.com/api/v2/...` is now broken — it rejects **all** valid POST requests, returning `400 Bad Request` with an `"Invalid JSON"` error regardless of payload content. This caused an `AuthenticationErrorException` during user login since the authentication token could no longer be retrieved.

The new backend at `app.jaststore.com` accepts the same API paths and request/response formats and works correctly.

**Fix:** Updated all 8 domain references across the codebase from `jastusa.com` to `jaststore.com`:
- `JastUrls.cs` — BaseApiUrl
- `JastUsaApiClient.cs` — hardcoded translations URL
- `JastUsaWebUrls.cs` — JastBaseAppUrl, MyAccountPage, JastMediaUrlTemplate
- `JastUsaLibraryMetadataProvider.cs` — product API URL and store link
- `JastUsaLibraryClient.cs` — browser open URL

#### 2. Library Sync Deserialization Crash
After fixing the domain, library sync still failed. The new `jaststore.com` API introduced a new `@type` value for game translations: `"GameLinkLocale"`. The existing `TranslationType` enum and its custom `EnUsTypeConverter` only recognized `"GameLinkTranslation"` and threw an exception on any other value, crashing game imports.

**Fix:** Added `GameLinkLocale` to the `TranslationType` enum and updated the `EnUsTypeConverter` JSON converter to handle both values during serialization and deserialization.

### Files Changed
| File | Change |
|------|--------|
| `JastUrls.cs` | `app.jastusa.com` → `app.jaststore.com` |
| `JastUsaApiClient.cs` | Hardcoded translations URL domain |
| `JastUsaWebUrls.cs` | 3 URL constants updated |
| `JastUsaLibraryMetadataProvider.cs` | Product API URL + store link |
| `JastUsaLibraryClient.cs` | Browser open URL |
| `GetGamesResponse.cs` | Added `GameLinkLocale` to enum + converter |

### Testing
- ✅ Authentication works — users can log in successfully
- ✅ Library sync works — games import without JSON deserialization errors
- ✅ Verified via API testing that `app.jaststore.com` endpoints respond correctly