### PR TITLE
Add EmuMovies video provider to Extra Metadata Loader

### DIFF
--- a/source/Generic/ExtraMetadataLoader/ExtraMetadataLoader.cs
+++ b/source/Generic/ExtraMetadataLoader/ExtraMetadataLoader.cs
@@ -151,10 +151,14 @@ namespace ExtraMetadataLoader
             services.AddTransient<LogoProcessor>();
             services.AddTransient<VideoProcessor>();
             services.AddTransient(provider => provider.GetService<ExtraMetadataLoaderSettingsViewModel>().Settings);
+            services.AddSingleton(new EmuMoviesCredentialsStore(GetPluginUserDataPath(), _logger));
 
             services.AddTransient<SteamMetadataProvider>();
+            services.AddTransient<EmuMoviesVideoService>();
+            services.AddTransient<EmuMoviesVideoProvider>();
             services.AddTransient<ILogoProvider>(provider => provider.GetService<SteamMetadataProvider>());
             services.AddTransient<IVideoProvider>(provider => provider.GetService<SteamMetadataProvider>());
+            services.AddTransient<IVideoProvider>(provider => provider.GetService<EmuMoviesVideoProvider>());
 
             services.AddTransient<ILogoProvider, SteamMetadataProvider>();
             services.AddTransient<ILogoProvider, SteamGridDBProvider>();
@@ -509,6 +513,46 @@ namespace ExtraMetadataLoader
                 },
                 new GameMenuItem
                 {
+                    Description = ResourceProvider.GetString("LOCExtra_Metadata_Loader_MenuItemDescriptionDownloadEmuMoviesVideosSelectedGames"),
+                    MenuSection = $"Extra Metadata|{videosSection}|{videosSection}",
+                    Icon = "emtDownloadIcon",
+                    Action = _ =>
+                    {
+                        if (!ValidateExecutablesSettings(true, false))
+                        {
+                            return;
+                        }
+                        var overwrite = GetBoolFromYesNoDialog(ResourceProvider.GetString("LOCExtra_Metadata_Loader_DialogMessageOverwriteVideosChoice"));
+                        var selectAutomatically = GetBoolFromYesNoDialog(ResourceProvider.GetString("LOCExtra_Metadata_Loader_DialogAskSelectVideosAutomatically"));
+                        var progressTitle = ResourceProvider.GetString("LOCExtra_Metadata_Loader_DialogMessageDownloadingVideosEmuMovies");
+                        var metadataDownloadService = _serviceProvider.GetRequiredService<MetadataDownloadService>();
+                        var videoProvider = metadataDownloadService.GetVideoProviderById(EmuMoviesVideoService.ProviderId);
+
+                        var progressOptions = new GlobalProgressOptions(progressTitle, true);
+                        progressOptions.IsIndeterminate = false;
+                        ClearVideoSources();
+                        PlayniteApi.Dialogs.ActivateGlobalProgress((a) =>
+                        {
+                            var games = args.Games.Distinct();
+                            a.ProgressMaxValue = games.Count() + 1;
+                            foreach (var game in games)
+                            {
+                                if (a.CancelToken.IsCancellationRequested)
+                                {
+                                    break;
+                                }
+
+                                a.CurrentProgressValue++;
+                                a.Text = $"{progressTitle}\n\n{a.CurrentProgressValue}/{games.Count()}\n{game.Name}";
+                                metadataDownloadService.DownloadVideoAsync(videoProvider, game, false, overwrite, a.CancelToken, selectAutomatically).GetAwaiter().GetResult();
+                            };
+                        }, progressOptions);
+                        UpdatePlayersData();
+                        PlayniteApi.Dialogs.ShowMessage(ResourceProvider.GetString("LOCExtra_Metadata_Loader_DialogMessageDone"), "Extra Metadata Loader");
+                    }
+                },
+                new GameMenuItem
+                {
                     Description = ResourceProvider.GetString("LOCExtra_Metadata_Loader_MenuItemDescriptionDownloadVideoFromYoutube"),
                     MenuSection = $"Extra Metadata|{videosSection}|{videosSection}",
                     Icon = "emtYoutubeIcon",
@@ -749,6 +793,18 @@ namespace ExtraMetadataLoader
             return gameMenuItems;
         }
 
+        private bool GetGameLogo(ILogoProvider logoProvider, Game game, bool isBackgroundDownload, bool overwrite, CancellationToken cancelToken = default)
+        {
+            var metadataDownloadService = _serviceProvider.GetRequiredService<MetadataDownloadService>();
+            return metadataDownloadService.DownloadLogoAsync(logoProvider, game, isBackgroundDownload, overwrite, cancelToken).GetAwaiter().GetResult();
+        }
+
+        private void ProcessLogoImage(string logoPath)
+        {
+            var logoProcessor = _serviceProvider.GetRequiredService<LogoProcessor>();
+            logoProcessor.ProcessLogoImage(logoPath);
+        }
+
         private string GetPlatformName(Game game, bool appendSpace = false)
         {
             if (!game.Platforms.HasItems())
@@ -901,7 +957,14 @@ namespace ExtraMetadataLoader
                 var progressTitle = ResourceProvider.GetString("LOCExtra_Metadata_Loader_DialogMessageLibUpdateAutomaticDownloadVideos");
                 var progressOptions = new GlobalProgressOptions(progressTitle, true);
                 progressOptions.IsIndeterminate = false;
-                var downloadOptions = new VideoDownloadOptions(VideoType.Trailer,);
+                var emuMoviesVideoProvider = metadataDownloadService.GetVideoProviderById(EmuMoviesVideoService.ProviderId);
+                var automaticVideoDownloadSource = settings.Settings.AutomaticVideoDownloadSource;
+                var downloadSteamVideo = settings.Settings.DownloadVideosOnLibUpdate &&
+                                         (automaticVideoDownloadSource == AutomaticVideoDownloadSource.Steam ||
+                                          automaticVideoDownloadSource == AutomaticVideoDownloadSource.SteamThenEmuMovies);
+                var downloadEmuMoviesVideo = settings.Settings.DownloadVideosOnLibUpdate &&
+                                             (automaticVideoDownloadSource == AutomaticVideoDownloadSource.EmuMovies ||
+                                              automaticVideoDownloadSource == AutomaticVideoDownloadSource.SteamThenEmuMovies);
                 PlayniteApi.Dialogs.ActivateGlobalProgress((a) =>
                 {
                     var games = PlayniteApi.Database.Games.Where(x => x.Added.HasValue && x.Added > settings.Settings.LastAutoLibUpdateAssetsDownload);
@@ -915,7 +978,15 @@ namespace ExtraMetadataLoader
 
                         a.CurrentProgressValue++;
                         a.Text = $"{progressTitle}\n\n{a.CurrentProgressValue}/{games.Count()}\n{game.Name}";
-                        videosDownloader.DownloadSteamVideo(game, false, true, a.CancelToken, settings.Settings.DownloadVideosOnLibUpdate, settings.Settings.DownloadVideosMicroOnLibUpdate);
+                        if (downloadSteamVideo || settings.Settings.DownloadVideosMicroOnLibUpdate)
+                        {
+                            videosDownloader.DownloadSteamVideo(game, false, true, a.CancelToken, downloadSteamVideo, settings.Settings.DownloadVideosMicroOnLibUpdate);
+                        }
+
+                        if (downloadEmuMoviesVideo && !FileSystem.FileExists(ExtraMetadataHelper.GetGameVideoPath(game)))
+                        {
+                            metadataDownloadService.DownloadVideoAsync(emuMoviesVideoProvider, game, true, false, a.CancelToken).GetAwaiter().GetResult();
+                        }
                     };
                 }, progressOptions);
             }

--- a/source/Generic/ExtraMetadataLoader/ExtraMetadataLoader.csproj
+++ b/source/Generic/ExtraMetadataLoader/ExtraMetadataLoader.csproj
@@ -192,6 +192,14 @@
     <Compile Include="MetadataProviders\Result.cs" />
     <Compile Include="MetadataProviders\SteamGridDB\SteamGridDBProvider.cs" />
     <Compile Include="MetadataProviders\Steam\SteamMetadataProvider.cs" />
+    <Compile Include="MetadataProviders\EmuMovies\EmuMoviesCredentials.cs" />
+    <Compile Include="MetadataProviders\EmuMovies\EmuMoviesCredentialsStore.cs" />
+    <Compile Include="MetadataProviders\EmuMovies\EmuMoviesFtpClient.cs" />
+    <Compile Include="MetadataProviders\EmuMovies\EmuMoviesPlatformMapper.cs" />
+    <Compile Include="MetadataProviders\EmuMovies\EmuMoviesVideoFile.cs" />
+    <Compile Include="MetadataProviders\EmuMovies\EmuMoviesVideoMatch.cs" />
+    <Compile Include="MetadataProviders\EmuMovies\EmuMoviesVideoProvider.cs" />
+    <Compile Include="MetadataProviders\EmuMovies\EmuMoviesVideoService.cs" />
     <Compile Include="VideosProcessor\FfprobeVideoInfoOutput.cs" />
     <Compile Include="MetadataProviders\Google\GoogleImage.cs" />
     <Compile Include="Models\LogoControlThemeSettings.cs" />

--- a/source/Generic/ExtraMetadataLoader/ExtraMetadataLoaderSettings.cs
+++ b/source/Generic/ExtraMetadataLoader/ExtraMetadataLoaderSettings.cs
@@ -1,15 +1,32 @@
 ﻿using Playnite.SDK;
 using Playnite.SDK.Data;
+using ExtraMetadataLoader.MetadataProviders;
 using PluginsCommon;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace ExtraMetadataLoader
 {
+    public enum EmuMoviesVideoQuality
+    {
+        HD,
+        HQ,
+        SQ
+    }
+
+    public enum AutomaticVideoDownloadSource
+    {
+        Steam,
+        EmuMovies,
+        SteamThenEmuMovies
+    }
+
     public class ExtraMetadataLoaderSettings : ObservableObject
     {
         [DontSerialize]
@@ -569,6 +586,42 @@ namespace ExtraMetadataLoader
         }
 
         [DontSerialize]
+        private EmuMoviesVideoQuality emuMoviesVideoQuality { get; set; } = EmuMoviesVideoQuality.HQ;
+        public EmuMoviesVideoQuality EmuMoviesVideoQuality
+        {
+            get => emuMoviesVideoQuality;
+            set
+            {
+                emuMoviesVideoQuality = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DontSerialize]
+        private bool emuMoviesPreferBestAvailableVideoQuality { get; set; } = true;
+        public bool EmuMoviesPreferBestAvailableVideoQuality
+        {
+            get => emuMoviesPreferBestAvailableVideoQuality;
+            set
+            {
+                emuMoviesPreferBestAvailableVideoQuality = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DontSerialize]
+        private AutomaticVideoDownloadSource automaticVideoDownloadSource { get; set; } = AutomaticVideoDownloadSource.Steam;
+        public AutomaticVideoDownloadSource AutomaticVideoDownloadSource
+        {
+            get => automaticVideoDownloadSource;
+            set
+            {
+                automaticVideoDownloadSource = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DontSerialize]
         private bool steamDlOnlyProcessPcGames = true;
         public bool SteamDlOnlyProcessPcGames
         {
@@ -750,6 +803,7 @@ namespace ExtraMetadataLoader
     {
         private readonly ExtraMetadataLoader plugin;
         private readonly IPlayniteAPI playniteApi;
+        private readonly EmuMoviesCredentialsStore emuMoviesCredentialsStore;
 
         private ExtraMetadataLoaderSettings editingClone { get; set; }
 
@@ -764,11 +818,34 @@ namespace ExtraMetadataLoader
             }
         }
 
+        private string emuMoviesUsername = string.Empty;
+        public string EmuMoviesUsername
+        {
+            get => emuMoviesUsername;
+            set
+            {
+                emuMoviesUsername = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string emuMoviesCredentialStatus = string.Empty;
+        public string EmuMoviesCredentialStatus
+        {
+            get => emuMoviesCredentialStatus;
+            set
+            {
+                emuMoviesCredentialStatus = value;
+                OnPropertyChanged();
+            }
+        }
+
         public ExtraMetadataLoaderSettingsViewModel(ExtraMetadataLoader plugin, IPlayniteAPI playniteApi)
         {
             // Injecting your plugin instance is required for Save/Load method because Playnite saves data to a location based on what plugin requested the operation.
             this.plugin = plugin;
             this.playniteApi = playniteApi;
+            emuMoviesCredentialsStore = new EmuMoviesCredentialsStore(plugin.GetPluginUserDataPath(), LogManager.GetLogger());
             // Load saved settings.
             var savedSettings = plugin.LoadPluginSettings<ExtraMetadataLoaderSettings>();
 
@@ -781,12 +858,15 @@ namespace ExtraMetadataLoader
             {
                 Settings = new ExtraMetadataLoaderSettings();
             }
+
+            LoadEmuMoviesCredentials();
         }
 
         public void BeginEdit()
         {
             // Code executed when settings view is opened and user starts editing values.
             editingClone = Serialization.GetClone(Settings);
+            LoadEmuMoviesCredentials();
         }
 
         public void CancelEdit()
@@ -794,6 +874,7 @@ namespace ExtraMetadataLoader
             // Code executed when user decides to cancel any changes made since BeginEdit was called.
             // This method should revert any changes made to Option1 and Option2.
             Settings = editingClone;
+            LoadEmuMoviesCredentials();
         }
 
         public void EndEdit()
@@ -866,6 +947,91 @@ namespace ExtraMetadataLoader
             {
                 LoginToYoutube();
             });
+        }
+
+        public RelayCommand<object> SaveEmuMoviesCredentialsCommand
+        {
+            get => new RelayCommand<object>((a) =>
+            {
+                var credentials = GetEmuMoviesCredentialsFromInput(a, true);
+                if (credentials?.IsConfigured != true)
+                {
+                    UpdateEmuMoviesCredentialStatus(ResourceProvider.GetString("LOCExtra_Metadata_Loader_SettingsEmuMoviesCredentialsNotConfiguredLabel"));
+                    return;
+                }
+
+                UpdateEmuMoviesCredentialStatus(ResourceProvider.GetString(emuMoviesCredentialsStore.Save(credentials)
+                    ? "LOCExtra_Metadata_Loader_SettingsEmuMoviesCredentialsSavedMessage"
+                    : "LOCExtra_Metadata_Loader_SettingsEmuMoviesCredentialsNotConfiguredLabel"));
+            });
+        }
+
+        public RelayCommand<object> TestEmuMoviesCredentialsCommand
+        {
+            get => new RelayCommand<object>((a) =>
+            {
+                var credentials = GetEmuMoviesCredentialsFromInput(a, true);
+                if (credentials?.IsConfigured != true)
+                {
+                    UpdateEmuMoviesCredentialStatus(ResourceProvider.GetString("LOCExtra_Metadata_Loader_SettingsEmuMoviesCredentialsNotConfiguredLabel"));
+                    return;
+                }
+
+                var client = new EmuMoviesFtpClient(credentials.Username, credentials.Password, Settings.EmuMoviesVideoQuality, LogManager.GetLogger());
+                var success = client.TestConnection();
+                UpdateEmuMoviesCredentialStatus(ResourceProvider.GetString(success
+                    ? "LOCExtra_Metadata_Loader_SettingsEmuMoviesConnectionSuccessMessage"
+                    : "LOCExtra_Metadata_Loader_SettingsEmuMoviesConnectionFailureMessage"));
+            });
+        }
+
+        public RelayCommand<object> ClearEmuMoviesCredentialsCommand
+        {
+            get => new RelayCommand<object>((a) =>
+            {
+                emuMoviesCredentialsStore.Clear();
+                EmuMoviesUsername = string.Empty;
+                if (a is PasswordBox passwordBox)
+                {
+                    passwordBox.Password = string.Empty;
+                }
+
+                UpdateEmuMoviesCredentialStatus(ResourceProvider.GetString("LOCExtra_Metadata_Loader_SettingsEmuMoviesCredentialsClearedMessage"));
+            });
+        }
+
+        private EmuMoviesCredentials GetEmuMoviesCredentialsFromInput(object parameter, bool allowStoredPassword)
+        {
+            var password = (parameter as PasswordBox)?.Password;
+            if (password.IsNullOrWhiteSpace() && allowStoredPassword)
+            {
+                var storedCredentials = emuMoviesCredentialsStore.Load();
+                if (storedCredentials != null &&
+                    storedCredentials.Username.Equals(EmuMoviesUsername, StringComparison.OrdinalIgnoreCase))
+                {
+                    password = storedCredentials.Password;
+                }
+            }
+
+            return new EmuMoviesCredentials
+            {
+                Username = EmuMoviesUsername?.Trim(),
+                Password = password
+            };
+        }
+
+        private void LoadEmuMoviesCredentials()
+        {
+            var credentials = emuMoviesCredentialsStore.Load();
+            EmuMoviesUsername = credentials?.Username ?? string.Empty;
+            UpdateEmuMoviesCredentialStatus(ResourceProvider.GetString(credentials?.IsConfigured == true
+                ? "LOCExtra_Metadata_Loader_SettingsEmuMoviesCredentialsConfiguredLabel"
+                : "LOCExtra_Metadata_Loader_SettingsEmuMoviesCredentialsNotConfiguredLabel"));
+        }
+
+        private void UpdateEmuMoviesCredentialStatus(string status)
+        {
+            EmuMoviesCredentialStatus = status;
         }
 
         public void LoginToYoutube()

--- a/source/Generic/ExtraMetadataLoader/ExtraMetadataLoaderSettingsView.xaml
+++ b/source/Generic/ExtraMetadataLoader/ExtraMetadataLoaderSettingsView.xaml
@@ -86,6 +86,43 @@
                         <CheckBox IsChecked="{Binding Settings.DownloadVideosMicroOnLibUpdate, UpdateSourceTrigger=PropertyChanged}" Content="{DynamicResource LOCExtra_Metadata_Loader_SettingsDownloadVideosMicroOnLibUpdateLabel}" Margin="0,0,0,20"/>
                         <CheckBox IsChecked="{Binding Settings.VideoSteamDownloadHdQuality, UpdateSourceTrigger=PropertyChanged}" Content="{DynamicResource LOCExtra_Metadata_Loader_SettingDownloadSteamVideosInHdLabel}" Margin="0,0,0,10"/>
                         <CheckBox IsChecked="{Binding Settings.SteamDlOnlyProcessPcGames, UpdateSourceTrigger=PropertyChanged}" Content="{DynamicResource LOCExtra_Metadata_Loader_SettingSteamDlOnlyProcessPcGamesLabel}" Margin="0,0,0,10"/>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                            <Label Content="{DynamicResource LOCExtra_Metadata_Loader_SettingsAutomaticVideoDownloadSourceLabel}" VerticalAlignment="Center" />
+                            <ComboBox x:Name="cmbAutomaticVideoDownloadSource" MinWidth="180" HorizontalAlignment="Left"
+                                      DisplayMemberPath="Value"
+                                      SelectedValuePath="Key"
+                                      SelectedValue="{Binding Settings.AutomaticVideoDownloadSource, UpdateSourceTrigger=PropertyChanged}" Margin="10,0,0,0"/>
+                        </StackPanel>
+                        <Label Content="{DynamicResource LOCExtra_Metadata_Loader_SettingsSectionLabelEmuMovies}" Margin="0,10,0,5"/>
+                        <Separator Margin="0,0,0,5" />
+                        <DockPanel Margin="0,0,0,10">
+                            <TextBlock Text="{DynamicResource LOCExtra_Metadata_Loader_SettingsEmuMoviesUsernameLabel}" DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                            <TextBox Margin="10,0,0,0" Text="{Binding EmuMoviesUsername, UpdateSourceTrigger=PropertyChanged}" />
+                        </DockPanel>
+                        <DockPanel Margin="0,0,0,10">
+                            <TextBlock Text="{DynamicResource LOCExtra_Metadata_Loader_SettingsEmuMoviesPasswordLabel}" DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                            <PasswordBox x:Name="PbEmuMoviesPassword" Margin="10,0,0,0" />
+                        </DockPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                            <Button Content="{DynamicResource LOCExtra_Metadata_Loader_SettingsEmuMoviesSaveCredentialsLabel}"
+                                    Command="{Binding SaveEmuMoviesCredentialsCommand}"
+                                    CommandParameter="{Binding ElementName=PbEmuMoviesPassword}" />
+                            <Button Margin="10,0,0,0" Content="{DynamicResource LOCExtra_Metadata_Loader_SettingsEmuMoviesTestConnectionLabel}"
+                                    Command="{Binding TestEmuMoviesCredentialsCommand}"
+                                    CommandParameter="{Binding ElementName=PbEmuMoviesPassword}" />
+                            <Button Margin="10,0,0,0" Content="{DynamicResource LOCExtra_Metadata_Loader_SettingsEmuMoviesClearCredentialsLabel}"
+                                    Command="{Binding ClearEmuMoviesCredentialsCommand}"
+                                    CommandParameter="{Binding ElementName=PbEmuMoviesPassword}" />
+                        </StackPanel>
+                        <TextBlock Text="{Binding EmuMoviesCredentialStatus}" Margin="0,0,0,10" />
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                            <Label Content="{DynamicResource LOCExtra_Metadata_Loader_SettingsEmuMoviesQualityLabel}" VerticalAlignment="Center" />
+                            <ComboBox x:Name="cmbEmuMoviesVideoQuality" MinWidth="120" HorizontalAlignment="Left"
+                                      DisplayMemberPath="Value"
+                                      SelectedValuePath="Key"
+                                      SelectedValue="{Binding Settings.EmuMoviesVideoQuality, UpdateSourceTrigger=PropertyChanged}" Margin="10,0,0,0"/>
+                        </StackPanel>
+                        <CheckBox IsChecked="{Binding Settings.EmuMoviesPreferBestAvailableVideoQuality, UpdateSourceTrigger=PropertyChanged}" Content="{DynamicResource LOCExtra_Metadata_Loader_SettingsEmuMoviesPreferBestAvailableVideoQualityLabel}" Margin="0,0,0,20"/>
                         <Label Content="{DynamicResource LOCExtra_Metadata_Loader_SettingsSectionLabelVideoPlayerControl}" Margin="0,20,0,5"/>
                         <Separator Margin="0,0,0,5" />
                         <CheckBox Name="EnableVideo" IsChecked="{Binding Settings.EnableVideoPlayer, UpdateSourceTrigger=PropertyChanged}" Content="{DynamicResource LOCExtra_Metadata_Loader_Browser_SettingVideoEnablePlayerLabel}" Margin="0,0,0,10"/>

--- a/source/Generic/ExtraMetadataLoader/ExtraMetadataLoaderSettingsView.xaml.cs
+++ b/source/Generic/ExtraMetadataLoader/ExtraMetadataLoaderSettingsView.xaml.cs
@@ -40,6 +40,20 @@ namespace ExtraMetadataLoader
                 { VerticalAlignment.Top, ResourceProvider.GetString("LOCExtra_Metadata_Loader_Browser_OptionVerticalAlignmentTop") },
                 { VerticalAlignment.Bottom, ResourceProvider.GetString("LOCExtra_Metadata_Loader_Browser_OptionVerticalAlignmentBottom") },
             };
+
+            cmbAutomaticVideoDownloadSource.ItemsSource = new Dictionary<AutomaticVideoDownloadSource, string>
+            {
+                { AutomaticVideoDownloadSource.Steam, ResourceProvider.GetString("LOCExtra_Metadata_Loader_SettingsAutomaticVideoDownloadSourceSteam") },
+                { AutomaticVideoDownloadSource.EmuMovies, ResourceProvider.GetString("LOCExtra_Metadata_Loader_SettingsAutomaticVideoDownloadSourceEmuMovies") },
+                { AutomaticVideoDownloadSource.SteamThenEmuMovies, ResourceProvider.GetString("LOCExtra_Metadata_Loader_SettingsAutomaticVideoDownloadSourceSteamThenEmuMovies") },
+            };
+
+            cmbEmuMoviesVideoQuality.ItemsSource = new Dictionary<EmuMoviesVideoQuality, string>
+            {
+                { EmuMoviesVideoQuality.HD, ResourceProvider.GetString("LOCExtra_Metadata_Loader_EmuMoviesVideoQualityHD") },
+                { EmuMoviesVideoQuality.HQ, ResourceProvider.GetString("LOCExtra_Metadata_Loader_EmuMoviesVideoQualityHQ") },
+                { EmuMoviesVideoQuality.SQ, ResourceProvider.GetString("LOCExtra_Metadata_Loader_EmuMoviesVideoQualitySQ") },
+            };
         }
     }
 }

--- a/source/Generic/ExtraMetadataLoader/Localization/en_US.xaml
+++ b/source/Generic/ExtraMetadataLoader/Localization/en_US.xaml
@@ -33,6 +33,7 @@
     <sys:String x:Key="LOCExtra_Metadata_Loader_Browser_SettingLogosEffectBrightnessLabel">Brightness</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_Browser_SettingLogosEffectMaxLuminanceLabel">Maximum luminance</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsSectionLabelVideoDownload">Video download settings</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsSectionLabelEmuMovies">EmuMovies</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsSectionLabelVideoDetailsView">Details View player settings</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsSectionLabelVideoGridView">Grid View player settings</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsSectionLabelVideoOtherView">Other views player settings</sys:String>
@@ -47,6 +48,26 @@
     <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsLogosIncludeNsfwLabel">Include assets marked as "Adult Content" in searches</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsDownloadVideosOnLibUpdateLabel">Download videos of newly added games on library update</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsDownloadVideosMicroOnLibUpdateLabel">Download Micro videos of newly added games on library update</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsAutomaticVideoDownloadSourceLabel">Automatic full-video source:</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsAutomaticVideoDownloadSourceSteam">Steam</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsAutomaticVideoDownloadSourceEmuMovies">EmuMovies</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsAutomaticVideoDownloadSourceSteamThenEmuMovies">Steam, then EmuMovies</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesUsernameLabel">Username:</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesPasswordLabel">Password:</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesSaveCredentialsLabel">Save</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesTestConnectionLabel">Test</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesClearCredentialsLabel">Clear</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesCredentialsConfiguredLabel">EmuMovies credentials are saved.</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesCredentialsNotConfiguredLabel">EmuMovies credentials are not configured.</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesCredentialsSavedMessage">EmuMovies credentials saved.</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesCredentialsClearedMessage">EmuMovies credentials cleared.</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesConnectionSuccessMessage">EmuMovies connection succeeded.</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesConnectionFailureMessage">EmuMovies connection failed.</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesQualityLabel">Video quality:</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsEmuMoviesPreferBestAvailableVideoQualityLabel">Prefer best available video quality (HD, HQ, SQ)</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_EmuMoviesVideoQualityHD">HD</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_EmuMoviesVideoQualityHQ">HQ</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_EmuMoviesVideoQualitySQ">SQ</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsDownloadLogosOnLibUpdateLabel">Download logos of newly added games on library update</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_SettingsDownloadLogosOnLibUpdateSelectLogosAutomaticallyLabel">Select logos to download automatically</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_VideoLabel">Video</sys:String>
@@ -64,6 +85,7 @@
     <sys:String x:Key="LOCExtra_Metadata_Loader_DialogMessageOverwriteLogosChoice">Overwrite logos of games that already have them?</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_DialogMessageOverwriteVideosChoice">Overwrite videos of games that already have them?</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_DialogMessageDownloadingVideosSteam">Downloading videos from Steam...</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_DialogMessageDownloadingVideosEmuMovies">Downloading videos from EmuMovies...</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_DialogMessageDownloadingVideosMicroSteam">Downloading Micro videos from Steam...</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_DialogMessageDownloadingLogosSteam">Downloading logos from Steam...</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_DialogMessageDownloadingLogosSgdb">Downloading logos from SteamGridDB...</sys:String>
@@ -82,9 +104,11 @@ Please verify that your yt-dlp installation is up to date.</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_NotificationMessageFfprobeNotFound">Extra Metadata: ffprobe executable was not found in the configured location</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_NotificationMessageYoutubeDlNotConfigured">Extra Metadata: yt-dlp executable path has not been configured in the extension settings</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_NotificationMessageYoutubeDlNotFound">Extra Metadata: yt-dlp executable was not found in the configured location</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_NotificationMessageEmuMoviesCredentialsMissing">Extra Metadata: EmuMovies credentials have not been configured in settings</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_NotificationMessageErrorDeletingFile">Extra Metadata: Error deleting file in {0}. Error: {1}</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_NotificationMessageErrorDeletingDirectory">Extra Metadata: Error deleting directory in {0}. Error: {1}</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_MenuItemDescriptionDownloadSteamVideosSelectedGames">Download videos from Steam for selected games</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_MenuItemDescriptionDownloadEmuMoviesVideosSelectedGames">Download videos from EmuMovies for selected games</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_MenuItemDescriptionDownloadSteamVideosMicroSelectedGames">Download Micro videos from Steam for selected games</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_MenuItemDescriptionDownloadSteamLogosSelectedGames">Download logos from Steam for selected games</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_MenuItemDescriptionDownloadSgdbLogosSelectedGames">Download logos from SteamGridDB for selected games</sys:String>
@@ -155,6 +179,10 @@ Resizing down is recommended because large images can cause Playnite to slowdown
     
 Select "Yes" to automatically select the logos to download without any user interaction.
 Select "No" to manually make selections when necessary.</sys:String>
+    <sys:String x:Key="LOCExtra_Metadata_Loader_DialogAskSelectVideosAutomatically" xml:space="preserve">Select videos to download automatically?
+
+Select &quot;Yes&quot; to automatically select the videos to download without any user interaction.
+Select &quot;No&quot; to manually make selections when necessary.</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_NotificationErrorFfprobeGetInfoFail" xml:space="preserve">Extra Metadata Loader
 Failed to get video information: {0}, {1}, {2}.</sys:String>
     <sys:String x:Key="LOCExtra_Metadata_Loader_NotificationErrorFfmpegProcessingFail" xml:space="preserve">Extra Metadata Loader

--- a/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesCredentials.cs
+++ b/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesCredentials.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace ExtraMetadataLoader.MetadataProviders
+{
+    internal class EmuMoviesCredentials
+    {
+        public string Username { get; set; }
+        public string Password { get; set; }
+
+        public bool IsConfigured =>
+            !Username.IsNullOrWhiteSpace() &&
+            !Password.IsNullOrWhiteSpace();
+    }
+}

--- a/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesCredentialsStore.cs
+++ b/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesCredentialsStore.cs
@@ -1,0 +1,89 @@
+using Playnite.SDK;
+using Playnite.SDK.Data;
+using PluginsCommon;
+using System;
+using System.IO;
+using System.Security.Principal;
+using System.Text;
+
+namespace ExtraMetadataLoader.MetadataProviders
+{
+    internal class EmuMoviesCredentialsStore
+    {
+        private readonly string _credentialsPath;
+        private readonly ILogger _logger;
+
+        public EmuMoviesCredentialsStore(string pluginUserDataPath, ILogger logger)
+        {
+            var credentialsDirectory = Path.Combine(pluginUserDataPath, "EmuMovies");
+            Directory.CreateDirectory(credentialsDirectory);
+            _credentialsPath = Path.Combine(credentialsDirectory, "credentials.dat");
+            _logger = logger;
+        }
+
+        public EmuMoviesCredentials Load()
+        {
+            if (!FileSystem.FileExists(_credentialsPath))
+            {
+                return null;
+            }
+
+            try
+            {
+                var decryptedJson = Encryption.DecryptFromFile(_credentialsPath, Encoding.UTF8, GetEncryptionKey());
+                var credentials = Serialization.FromJson<EmuMoviesCredentials>(decryptedJson);
+                return credentials?.IsConfigured == true ? credentials : null;
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, "Failed to load EmuMovies credentials.");
+                FileSystem.DeleteFileSafe(_credentialsPath);
+                return null;
+            }
+        }
+
+        public bool Save(EmuMoviesCredentials credentials)
+        {
+            if (credentials?.IsConfigured != true)
+            {
+                return false;
+            }
+
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(_credentialsPath));
+                Encryption.EncryptToFile(
+                    _credentialsPath,
+                    Serialization.ToJson(credentials),
+                    Encoding.UTF8,
+                    GetEncryptionKey());
+                _logger.Debug("EmuMovies credentials saved successfully.");
+                return true;
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, "Failed to save EmuMovies credentials.");
+                FileSystem.DeleteFileSafe(_credentialsPath);
+                return false;
+            }
+        }
+
+        public void Clear()
+        {
+            if (FileSystem.FileExists(_credentialsPath))
+            {
+                FileSystem.DeleteFileSafe(_credentialsPath);
+            }
+        }
+
+        public bool HasCredentials()
+        {
+            return Load()?.IsConfigured == true;
+        }
+
+        private static string GetEncryptionKey()
+        {
+            return WindowsIdentity.GetCurrent()?.User?.Value ?? Environment.UserName;
+        }
+    }
+}

--- a/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesFtpClient.cs
+++ b/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesFtpClient.cs
@@ -1,0 +1,433 @@
+using Playnite.SDK;
+using PluginsCommon;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace ExtraMetadataLoader.MetadataProviders
+{
+    internal class EmuMoviesFtpClient
+    {
+        private const string PrimaryFtpHost = "files.emumovies.com";
+        private const string FallbackFtpHost = "files2.emumovies.com";
+        private const int TimeoutMilliseconds = 20000;
+        private const int MaxListAttempts = 3;
+        private const int ListRetryDelayMilliseconds = 750;
+
+        private static readonly string[] Hosts = { PrimaryFtpHost, FallbackFtpHost };
+        private static readonly HashSet<string> VideoExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".mp4",
+            ".avi",
+            ".mkv",
+            ".mov",
+            ".m4v",
+            ".webm"
+        };
+        private static readonly object CacheLock = new object();
+        private static readonly Dictionary<string, List<string>> QualityDirectoryCache = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, List<EmuMoviesVideoFile>> VideoFilesCache = new Dictionary<string, List<EmuMoviesVideoFile>>(StringComparer.OrdinalIgnoreCase);
+
+        private readonly string _username;
+        private readonly string _password;
+        private readonly List<EmuMoviesVideoQuality> _qualities;
+        private readonly ILogger _logger;
+
+        public EmuMoviesFtpClient(string username, string password, EmuMoviesVideoQuality quality, ILogger logger)
+            : this(username, password, new[] { quality }, logger)
+        {
+        }
+
+        public EmuMoviesFtpClient(string username, string password, IEnumerable<EmuMoviesVideoQuality> qualities, ILogger logger)
+        {
+            _username = username;
+            _password = password;
+            _qualities = qualities?.Distinct().ToList() ?? new List<EmuMoviesVideoQuality>();
+            if (!_qualities.HasItems())
+            {
+                _qualities.Add(EmuMoviesVideoQuality.HQ);
+            }
+
+            _logger = logger;
+        }
+
+        public bool TestConnection(CancellationToken cancelToken = default)
+        {
+            foreach (var host in Hosts)
+            {
+                if (cancelToken.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                try
+                {
+                    using (var response = GetFtpResponse(BuildRootUri(host), WebRequestMethods.Ftp.ListDirectory))
+                    {
+                        _logger.Debug($"EmuMovies FTP connection successful using {host}: {response.StatusDescription}");
+                        return true;
+                    }
+                }
+                catch (Exception e)
+                {
+                    _logger.Warn(e, $"EmuMovies FTP connection test failed using {host}.");
+                }
+            }
+
+            return false;
+        }
+
+        public List<EmuMoviesVideoFile> ListVideoFiles(string platformName, CancellationToken cancelToken)
+        {
+            if (platformName.IsNullOrWhiteSpace())
+            {
+                return new List<EmuMoviesVideoFile>();
+            }
+
+            var files = new List<EmuMoviesVideoFile>();
+            foreach (var quality in _qualities)
+            {
+                if (cancelToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                files.AddRange(ListVideoFiles(platformName, quality, cancelToken));
+            }
+
+            return files;
+        }
+
+        private List<EmuMoviesVideoFile> ListVideoFiles(string platformName, EmuMoviesVideoQuality quality, CancellationToken cancelToken)
+        {
+            var cacheKey = $"{quality}|{platformName}";
+            lock (CacheLock)
+            {
+                if (VideoFilesCache.TryGetValue(cacheKey, out var cachedFiles))
+                {
+                    return cachedFiles.ToList();
+                }
+            }
+
+            foreach (var host in Hosts)
+            {
+                if (cancelToken.IsCancellationRequested)
+                {
+                    return new List<EmuMoviesVideoFile>();
+                }
+
+                var qualityDirectoryUri = BuildQualityDirectoryUri(host, quality);
+                var platformDirectories = GetMatchingPlatformDirectories(host, quality, platformName, cancelToken);
+                if (!platformDirectories.HasItems())
+                {
+                    _logger.Debug($"No EmuMovies platform directories matched '{platformName}' in {qualityDirectoryUri}.");
+                    continue;
+                }
+
+                var files = new List<EmuMoviesVideoFile>();
+                foreach (var platformDirectory in platformDirectories)
+                {
+                    if (cancelToken.IsCancellationRequested)
+                    {
+                        return new List<EmuMoviesVideoFile>();
+                    }
+
+                    var platformDirectoryUri = AppendPathSegment(qualityDirectoryUri, platformDirectory);
+                    try
+                    {
+                        files.AddRange(ListVideoFiles(platformDirectoryUri, quality, platformName, platformDirectory));
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.Warn(e, $"Failed to list EmuMovies FTP directory {platformDirectoryUri}.");
+                    }
+                }
+
+                if (files.HasItems())
+                {
+                    lock (CacheLock)
+                    {
+                        VideoFilesCache[cacheKey] = files;
+                    }
+
+                    return files.ToList();
+                }
+            }
+
+            return new List<EmuMoviesVideoFile>();
+        }
+
+        private List<string> GetMatchingPlatformDirectories(
+            string host,
+            EmuMoviesVideoQuality quality,
+            string platformName,
+            CancellationToken cancelToken)
+        {
+            return ListQualityDirectories(host, quality, cancelToken)
+                .Select(x => new
+                {
+                    DirectoryName = x,
+                    Score = GetPlatformDirectoryScore(x, platformName)
+                })
+                .Where(x => x.Score >= 80)
+                .OrderByDescending(x => x.Score)
+                .ThenBy(x => x.DirectoryName)
+                .Select(x => x.DirectoryName)
+                .ToList();
+        }
+
+        private List<string> ListQualityDirectories(string host, EmuMoviesVideoQuality quality, CancellationToken cancelToken)
+        {
+            var cacheKey = $"{host}|{quality}";
+            lock (CacheLock)
+            {
+                if (QualityDirectoryCache.TryGetValue(cacheKey, out var cachedDirectories))
+                {
+                    return cachedDirectories.ToList();
+                }
+            }
+
+            if (cancelToken.IsCancellationRequested)
+            {
+                return new List<string>();
+            }
+
+            var qualityDirectoryUri = BuildQualityDirectoryUri(host, quality);
+            try
+            {
+                var directories = ListDirectoryEntries(qualityDirectoryUri)
+                    .Where(x => !x.IsNullOrWhiteSpace())
+                    .Where(x => !VideoExtensions.Contains(Path.GetExtension(x)))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(x => x)
+                    .ToList();
+
+                lock (CacheLock)
+                {
+                    QualityDirectoryCache[cacheKey] = directories;
+                }
+
+                return directories.ToList();
+            }
+            catch (Exception e)
+            {
+                _logger.Warn(e, $"Failed to list EmuMovies FTP quality directory {qualityDirectoryUri}.");
+                return new List<string>();
+            }
+        }
+
+        public bool DownloadVideo(string ftpPath, string destinationPath, CancellationToken cancelToken)
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
+                FileSystem.DeleteFile(destinationPath);
+
+                var request = CreateRequest(ftpPath, WebRequestMethods.Ftp.DownloadFile);
+                using (var response = (FtpWebResponse)request.GetResponse())
+                using (var responseStream = response.GetResponseStream())
+                using (var fileStream = File.Create(destinationPath))
+                {
+                    var buffer = new byte[81920];
+                    int bytesRead;
+                    while ((bytesRead = responseStream.Read(buffer, 0, buffer.Length)) > 0)
+                    {
+                        if (cancelToken.IsCancellationRequested)
+                        {
+                            FileSystem.DeleteFileSafe(destinationPath);
+                            return false;
+                        }
+
+                        fileStream.Write(buffer, 0, bytesRead);
+                    }
+                }
+
+                return FileSystem.FileExists(destinationPath);
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, $"Failed to download EmuMovies video from {ftpPath}.");
+                FileSystem.DeleteFileSafe(destinationPath);
+                return false;
+            }
+        }
+
+        private List<EmuMoviesVideoFile> ListVideoFiles(
+            string directoryUri,
+            EmuMoviesVideoQuality quality,
+            string platformName,
+            string platformDirectoryName)
+        {
+            var files = new List<EmuMoviesVideoFile>();
+            foreach (var entry in ListDirectoryEntries(directoryUri))
+            {
+                var fileName = GetFileName(entry);
+                if (!VideoExtensions.Contains(Path.GetExtension(fileName)))
+                {
+                    continue;
+                }
+
+                files.Add(new EmuMoviesVideoFile
+                {
+                    FileName = fileName,
+                    FtpPath = directoryUri + Uri.EscapeDataString(fileName),
+                    PlatformName = platformName,
+                    PlatformDirectoryName = platformDirectoryName,
+                    Quality = quality
+                });
+            }
+
+            return files;
+        }
+
+        private List<string> ListDirectoryEntries(string directoryUri)
+        {
+            var entries = new List<string>();
+            using (var response = GetFtpResponseWithRetry(directoryUri, WebRequestMethods.Ftp.ListDirectory))
+            using (var stream = response.GetResponseStream())
+            using (var reader = new StreamReader(stream))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    entries.Add(GetFileName(line));
+                }
+            }
+
+            return entries;
+        }
+
+        private FtpWebResponse GetFtpResponseWithRetry(string uri, string method)
+        {
+            Exception lastError = null;
+            for (var attempt = 1; attempt <= MaxListAttempts; attempt++)
+            {
+                try
+                {
+                    return GetFtpResponse(uri, method);
+                }
+                catch (Exception e)
+                {
+                    lastError = e;
+                    if (attempt == MaxListAttempts)
+                    {
+                        break;
+                    }
+
+                    _logger.Debug($"EmuMovies FTP {method} failed for {uri} on attempt {attempt}; retrying.");
+                    Thread.Sleep(ListRetryDelayMilliseconds * attempt);
+                }
+            }
+
+            throw lastError;
+        }
+
+        private FtpWebResponse GetFtpResponse(string uri, string method)
+        {
+            var request = CreateRequest(uri, method);
+            return (FtpWebResponse)request.GetResponse();
+        }
+
+        private FtpWebRequest CreateRequest(string uri, string method)
+        {
+            var request = (FtpWebRequest)WebRequest.Create(uri);
+            request.Method = method;
+            request.Credentials = new NetworkCredential(_username, _password);
+            request.UseBinary = true;
+            request.UsePassive = true;
+            request.KeepAlive = false;
+            request.Timeout = TimeoutMilliseconds;
+            request.ReadWriteTimeout = TimeoutMilliseconds;
+            return request;
+        }
+
+        private static int GetPlatformDirectoryScore(string directoryName, string platformName)
+        {
+            var directoryTokens = GetComparableTokens(GetPlatformNameFromDirectory(directoryName));
+            var platformTokens = GetComparableTokens(platformName);
+            if (!directoryTokens.HasItems() || !platformTokens.HasItems())
+            {
+                return 0;
+            }
+
+            if (!StartsWithTokens(directoryTokens, platformTokens))
+            {
+                return 0;
+            }
+
+            var extraTokenCount = directoryTokens.Count - platformTokens.Count;
+            if (extraTokenCount > 0 && IsVersionToken(directoryTokens[platformTokens.Count]))
+            {
+                return 0;
+            }
+
+            return Math.Max(80, 100 - (extraTokenCount * 3));
+        }
+
+        private static bool StartsWithTokens(List<string> directoryTokens, List<string> platformTokens)
+        {
+            if (directoryTokens.Count < platformTokens.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < platformTokens.Count; i++)
+            {
+                if (!directoryTokens[i].Equals(platformTokens[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static string GetPlatformNameFromDirectory(string directoryName)
+        {
+            return Regex.Replace(directoryName, @"\s*\(Video Snaps\).*", string.Empty, RegexOptions.IgnoreCase).Trim();
+        }
+
+        private static List<string> GetComparableTokens(string value)
+        {
+            if (value.IsNullOrWhiteSpace())
+            {
+                return new List<string>();
+            }
+
+            return Regex.Replace(value.ToLowerInvariant(), @"[^a-z0-9]+", " ")
+                .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                .ToList();
+        }
+
+        private static bool IsVersionToken(string token)
+        {
+            return Regex.IsMatch(token, @"^\d+$") ||
+                   Regex.IsMatch(token, @"^(i|ii|iii|iv|v|vi|vii|viii|ix|x)$", RegexOptions.IgnoreCase);
+        }
+
+        private static string BuildRootUri(string host)
+        {
+            return $"ftp://{host}/";
+        }
+
+        private static string BuildQualityDirectoryUri(string host, EmuMoviesVideoQuality quality)
+        {
+            var qualityPath = Uri.EscapeDataString($"Video Snaps ({quality})");
+            return $"ftp://{host}/Official/{qualityPath}/";
+        }
+
+        private static string AppendPathSegment(string baseUri, string pathSegment)
+        {
+            return baseUri.TrimEnd('/') + "/" + Uri.EscapeDataString(pathSegment) + "/";
+        }
+
+        private static string GetFileName(string ftpListEntry)
+        {
+            return ftpListEntry.Trim().TrimEnd('/').Split('/').LastOrDefault() ?? ftpListEntry;
+        }
+    }
+}

--- a/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesPlatformMapper.cs
+++ b/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesPlatformMapper.cs
@@ -1,0 +1,135 @@
+using Playnite.SDK.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExtraMetadataLoader.MetadataProviders
+{
+    internal static class EmuMoviesPlatformMapper
+    {
+        private static readonly Dictionary<string, string> PlatformMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "3DO", "3DO" },
+            { "Amiga", "Commodore Amiga" },
+            { "Arcade", "MAME" },
+            { "Atari 2600", "Atari 2600" },
+            { "Atari 5200", "Atari 5200" },
+            { "Atari 7800", "Atari 7800" },
+            { "Atari Jaguar", "Atari Jaguar" },
+            { "Atari Lynx", "Atari Lynx" },
+            { "ColecoVision", "Colecovision" },
+            { "Commodore 64", "Commodore 64" },
+            { "Dreamcast", "Sega Dreamcast" },
+            { "GBA", "Game Boy Advance" },
+            { "Game Boy", "Nintendo Game Boy" },
+            { "Game Boy Advance", "Nintendo Game Boy Advance" },
+            { "Game Boy Color", "Nintendo Game Boy Color" },
+            { "GameCube", "Nintendo Gamecube" },
+            { "MAME", "MAME" },
+            { "Microsoft Xbox", "Microsoft Xbox" },
+            { "Microsoft Xbox 360", "Microsoft Xbox 360" },
+            { "N64", "Nintendo 64" },
+            { "Neo Geo", "SNK Neo Geo" },
+            { "Neo Geo Pocket", "SNK Neo Geo Pocket" },
+            { "Neo Geo Pocket Color", "SNK Neo Geo Pocket Color" },
+            { "NES", "Nintendo Entertainment System" },
+            { "Nintendo 3DS", "Nintendo 3DS" },
+            { "Nintendo 64", "Nintendo 64" },
+            { "Nintendo DS", "Nintendo DS" },
+            { "Nintendo Entertainment System", "Nintendo Entertainment System" },
+            { "Nintendo GBA", "Nintendo GBA" },
+            { "Nintendo Game Boy", "Nintendo Game Boy" },
+            { "Nintendo Game Boy Advance", "Nintendo Game Boy Advance" },
+            { "Nintendo Game Boy Color", "Nintendo Game Boy Color" },
+            { "Nintendo GameCube", "Nintendo Gamecube" },
+            { "Nintendo Switch", "Nintendo Switch" },
+            { "Nintendo Wii", "Nintendo Wii" },
+            { "Nintendo Wii U", "Nintendo Wii U" },
+            { "PC", "Microsoft Windows" },
+            { "PC Engine", "NEC PC Engine" },
+            { "PlayStation", "Sony Playstation" },
+            { "PlayStation 2", "Sony Playstation 2" },
+            { "PlayStation 3", "Sony Playstation 3" },
+            { "PS2", "Sony Playstation 2" },
+            { "PS3", "Sony Playstation 3" },
+            { "PSP", "Sony PSP" },
+            { "PSX", "Sony Playstation" },
+            { "Nintendo SNES", "Super Nintendo Entertainment System" },
+            { "Nintendo Super Famicom", "Super Nintendo Entertainment System" },
+            { "Nintendo Super Nintendo", "Super Nintendo Entertainment System" },
+            { "Sega 32X", "Sega 32X" },
+            { "Sega CD", "Sega CD" },
+            { "Sega Dreamcast", "Sega Dreamcast" },
+            { "Sega Game Gear", "Sega Game Gear" },
+            { "Sega Genesis", "Sega Genesis" },
+            { "Sega Master System", "Sega Master System" },
+            { "Sega Mega Drive", "Sega Mega Drive" },
+            { "Sega Saturn", "Sega Saturn" },
+            { "SNES", "Super Nintendo Entertainment System" },
+            { "Super Famicom", "Super Nintendo Entertainment System" },
+            { "Super Nintendo", "Super Nintendo Entertainment System" },
+            { "Sony PlayStation", "Sony Playstation" },
+            { "Sony PlayStation 2", "Sony Playstation 2" },
+            { "Sony PlayStation 3", "Sony Playstation 3" },
+            { "Sony PSP", "Sony PSP" },
+            { "Super Nintendo Entertainment System", "Super Nintendo Entertainment System" },
+            { "Switch", "Nintendo Switch" },
+            { "TurboGrafx-16", "NEC TurboGrafx-16" },
+            { "Wii", "Nintendo Wii" },
+            { "Wii U", "Nintendo Wii U" },
+            { "Windows", "Microsoft Windows" },
+            { "Xbox", "Microsoft Xbox" },
+            { "Xbox 360", "Microsoft Xbox 360" }
+        };
+
+        private static readonly Dictionary<string, string[]> PlatformAliases = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "Nintendo Game Boy Advance", new[] { "Nintendo GBA", "GBA", "Game Boy Advance", "Nintendo Game Boy Advance" } },
+            { "Game Boy Advance", new[] { "Nintendo GBA", "GBA", "Game Boy Advance", "Nintendo Game Boy Advance" } },
+            { "Nintendo GBA", new[] { "Nintendo GBA", "GBA", "Game Boy Advance", "Nintendo Game Boy Advance" } },
+            { "GBA", new[] { "Nintendo GBA", "GBA", "Game Boy Advance", "Nintendo Game Boy Advance" } },
+            {
+                "Super Nintendo Entertainment System",
+                new[]
+                {
+                    "Nintendo Super Nintendo",
+                    "Super Nintendo",
+                    "Nintendo Super Famicom",
+                    "Super Famicom",
+                    "Nintendo SNES",
+                    "SNES"
+                }
+            }
+        };
+
+        public static List<string> GetEmuMoviesPlatforms(Game game)
+        {
+            if (game?.Platforms?.Any() != true)
+            {
+                return new List<string>();
+            }
+
+            return game.Platforms
+                .SelectMany(x => GetEmuMoviesPlatforms(x.Name))
+                .Where(x => !x.IsNullOrWhiteSpace())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static IEnumerable<string> GetEmuMoviesPlatforms(string playnitePlatformName)
+        {
+            if (playnitePlatformName.IsNullOrWhiteSpace())
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            var emuMoviesPlatform = PlatformMap.TryGetValue(playnitePlatformName, out var mappedPlatform)
+                ? mappedPlatform
+                : playnitePlatformName;
+
+            return PlatformAliases.TryGetValue(emuMoviesPlatform, out var aliases)
+                ? aliases
+                : new[] { emuMoviesPlatform };
+        }
+    }
+}

--- a/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesVideoFile.cs
+++ b/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesVideoFile.cs
@@ -1,0 +1,11 @@
+namespace ExtraMetadataLoader.MetadataProviders
+{
+    internal class EmuMoviesVideoFile
+    {
+        public string FileName { get; set; }
+        public string FtpPath { get; set; }
+        public string PlatformName { get; set; }
+        public string PlatformDirectoryName { get; set; }
+        public EmuMoviesVideoQuality Quality { get; set; }
+    }
+}

--- a/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesVideoMatch.cs
+++ b/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesVideoMatch.cs
@@ -1,0 +1,17 @@
+using System.IO;
+
+namespace ExtraMetadataLoader.MetadataProviders
+{
+    internal class EmuMoviesVideoMatch
+    {
+        public string FileName { get; set; }
+        public string FtpPath { get; set; }
+        public string PlatformName { get; set; }
+        public string PlatformDirectoryName { get; set; }
+        public EmuMoviesVideoQuality Quality { get; set; }
+        public int Score { get; set; }
+
+        public string DisplayName => $"{Path.GetFileNameWithoutExtension(FileName)} ({PlatformName}, {Quality})";
+        public string Description => $"{PlatformName} | {Quality} | {PlatformDirectoryName} | {FileName}";
+    }
+}

--- a/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesVideoProvider.cs
+++ b/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesVideoProvider.cs
@@ -1,0 +1,30 @@
+using Playnite.SDK.Models;
+using System.Threading;
+
+namespace ExtraMetadataLoader.MetadataProviders
+{
+    internal class EmuMoviesVideoProvider : IVideoProvider
+    {
+        private readonly EmuMoviesVideoService _videoService;
+
+        public string Id => EmuMoviesVideoService.ProviderId;
+
+        public EmuMoviesVideoProvider(EmuMoviesVideoService videoService)
+        {
+            _videoService = videoService;
+        }
+
+        public Result<VideoResult> GetVideo(Game game, VideoDownloadOptions downloadOptions, CancellationToken cancelToken)
+        {
+            if (downloadOptions.VideoType != VideoType.Trailer)
+            {
+                return Result<VideoResult>.Failure("EmuMovies only provides full trailer videos.");
+            }
+
+            var videoPath = _videoService.DownloadVideoToTempFile(game, downloadOptions.IsBackgroundDownload, downloadOptions.SelectAutomatically, cancelToken);
+            return string.IsNullOrWhiteSpace(videoPath)
+                ? Result<VideoResult>.Failure("EmuMovies video not found.")
+                : Result<VideoResult>.Success(VideoResult.FromFilePath(videoPath));
+        }
+    }
+}

--- a/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesVideoService.cs
+++ b/source/Generic/ExtraMetadataLoader/MetadataProviders/EmuMovies/EmuMoviesVideoService.cs
@@ -1,0 +1,298 @@
+using Playnite.SDK;
+using Playnite.SDK.Models;
+using PluginsCommon;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace ExtraMetadataLoader.MetadataProviders
+{
+    internal class EmuMoviesVideoService
+    {
+        public const string ProviderId = "emuMoviesProvider";
+
+        private static bool _missingCredentialsNotificationShown;
+
+        private readonly IPlayniteAPI _playniteApi;
+        private readonly ExtraMetadataLoaderSettings _settings;
+        private readonly EmuMoviesCredentialsStore _credentialsStore;
+        private readonly ILogger _logger;
+
+        public EmuMoviesVideoService(
+            IPlayniteAPI playniteApi,
+            ExtraMetadataLoaderSettings settings,
+            EmuMoviesCredentialsStore credentialsStore,
+            ILogger logger)
+        {
+            _playniteApi = playniteApi;
+            _settings = settings;
+            _credentialsStore = credentialsStore;
+            _logger = logger;
+        }
+
+        public string DownloadVideoToTempFile(Game game, bool isBackgroundDownload, bool selectAutomatically, CancellationToken cancelToken)
+        {
+            var credentials = _credentialsStore.Load();
+            if (credentials?.IsConfigured != true)
+            {
+                NotifyMissingCredentials(isBackgroundDownload);
+                return null;
+            }
+
+            var client = new EmuMoviesFtpClient(credentials.Username, credentials.Password, GetQualitySearchOrder(), _logger);
+            var selectedMatch = GetSelectedMatch(game, game.Name, client, isBackgroundDownload, selectAutomatically, cancelToken);
+            if (selectedMatch is null)
+            {
+                return null;
+            }
+
+            var tempFilePath = Path.Combine(
+                Path.GetTempPath(),
+                $"ExtraMetadataLoader_EmuMovies_{game.Id}_{Guid.NewGuid():N}{Path.GetExtension(selectedMatch.FileName)}");
+            return client.DownloadVideo(selectedMatch.FtpPath, tempFilePath, cancelToken) ? tempFilePath : null;
+        }
+
+        private EmuMoviesVideoMatch GetSelectedMatch(
+            Game game,
+            string searchTerm,
+            EmuMoviesFtpClient client,
+            bool isBackgroundDownload,
+            bool selectAutomatically,
+            CancellationToken cancelToken)
+        {
+            var matches = GetMatches(game, searchTerm, client, cancelToken);
+            if (!matches.HasItems())
+            {
+                return null;
+            }
+
+            var exactMatches = matches
+                .Where(x => IsExactMatch(x.FileName, searchTerm))
+                .ToList();
+            if (exactMatches.Count == 1)
+            {
+                return exactMatches[0];
+            }
+
+            if (exactMatches.Count > 1 && (isBackgroundDownload || selectAutomatically))
+            {
+                return exactMatches[0];
+            }
+
+            if (!exactMatches.HasItems() && IsConfidentMatch(matches))
+            {
+                return matches[0];
+            }
+
+            if (isBackgroundDownload)
+            {
+                return null;
+            }
+
+            if (selectAutomatically)
+            {
+                return matches[0];
+            }
+
+            var selectedItem = _playniteApi.Dialogs.ChooseItemWithSearch(
+                ToOptions(matches),
+                x => ToOptions(GetMatches(game, x, client, CancellationToken.None)),
+                game.Name.NormalizeGameName(),
+                ResourceProvider.GetString("LOCExtra_Metadata_Loader_DialogCaptionSelectGame"));
+
+            return selectedItem is null
+                ? null
+                : matches.FirstOrDefault(x => x.FtpPath == selectedItem.Description) ??
+                  FindMatchByFtpPath(game, selectedItem.Description, client, CancellationToken.None);
+        }
+
+        private EmuMoviesVideoMatch FindMatchByFtpPath(
+            Game game,
+            string ftpPath,
+            EmuMoviesFtpClient client,
+            CancellationToken cancelToken)
+        {
+            foreach (var platform in EmuMoviesPlatformMapper.GetEmuMoviesPlatforms(game))
+            {
+                if (cancelToken.IsCancellationRequested)
+                {
+                    return null;
+                }
+
+                var videoFile = client.ListVideoFiles(platform, cancelToken)
+                    .FirstOrDefault(x => x.FtpPath == ftpPath);
+                if (videoFile != null)
+                {
+                    return new EmuMoviesVideoMatch
+                    {
+                        FileName = videoFile.FileName,
+                        FtpPath = videoFile.FtpPath,
+                        PlatformName = videoFile.PlatformName,
+                        PlatformDirectoryName = videoFile.PlatformDirectoryName,
+                        Quality = videoFile.Quality
+                    };
+                }
+            }
+
+            return null;
+        }
+
+        private List<EmuMoviesVideoMatch> GetMatches(
+            Game game,
+            string searchTerm,
+            EmuMoviesFtpClient client,
+            CancellationToken cancelToken)
+        {
+            var platforms = EmuMoviesPlatformMapper.GetEmuMoviesPlatforms(game);
+            var matches = new List<EmuMoviesVideoMatch>();
+            foreach (var platform in platforms)
+            {
+                if (cancelToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                foreach (var videoFile in client.ListVideoFiles(platform, cancelToken))
+                {
+                    var score = GetMatchScore(videoFile.FileName, searchTerm);
+                    if (score < 70)
+                    {
+                        continue;
+                    }
+
+                    matches.Add(new EmuMoviesVideoMatch
+                    {
+                        FileName = videoFile.FileName,
+                        FtpPath = videoFile.FtpPath,
+                        PlatformName = videoFile.PlatformName,
+                        PlatformDirectoryName = videoFile.PlatformDirectoryName,
+                        Quality = videoFile.Quality,
+                        Score = score
+                    });
+                }
+            }
+
+            return matches
+                .OrderByDescending(x => x.Score)
+                .ThenBy(x => GetQualityPriority(x.Quality))
+                .ThenBy(x => x.FileName)
+                .ToList();
+        }
+
+        private List<EmuMoviesVideoQuality> GetQualitySearchOrder()
+        {
+            if (_settings.EmuMoviesPreferBestAvailableVideoQuality)
+            {
+                return new List<EmuMoviesVideoQuality>
+                {
+                    EmuMoviesVideoQuality.HD,
+                    EmuMoviesVideoQuality.HQ,
+                    EmuMoviesVideoQuality.SQ
+                };
+            }
+
+            return new List<EmuMoviesVideoQuality> { _settings.EmuMoviesVideoQuality };
+        }
+
+        private static int GetQualityPriority(EmuMoviesVideoQuality quality)
+        {
+            switch (quality)
+            {
+                case EmuMoviesVideoQuality.HD:
+                    return 0;
+                case EmuMoviesVideoQuality.HQ:
+                    return 1;
+                case EmuMoviesVideoQuality.SQ:
+                    return 2;
+                default:
+                    return 3;
+            }
+        }
+
+        private static List<GenericItemOption> ToOptions(IEnumerable<EmuMoviesVideoMatch> matches)
+        {
+            return matches
+                .Select(x => new GenericItemOption(x.DisplayName, x.FtpPath))
+                .ToList();
+        }
+
+        private static bool IsConfidentMatch(List<EmuMoviesVideoMatch> matches)
+        {
+            if (!matches.HasItems())
+            {
+                return false;
+            }
+
+            var topScore = matches[0].Score;
+            var nextScore = matches.Count > 1 ? matches[1].Score : 0;
+            return topScore >= 96 || (topScore >= 90 && topScore - nextScore >= 8);
+        }
+
+        private static bool IsExactMatch(string fileName, string searchTerm)
+        {
+            return NormalizeMatchValue(fileName) == NormalizeMatchValue(searchTerm);
+        }
+
+        private static int GetMatchScore(string fileName, string searchTerm)
+        {
+            var fileNameNormalized = NormalizeMatchValue(fileName);
+            var searchTermNormalized = NormalizeMatchValue(searchTerm);
+            if (fileNameNormalized.IsNullOrWhiteSpace() || searchTermNormalized.IsNullOrWhiteSpace())
+            {
+                return 0;
+            }
+
+            if (fileNameNormalized == searchTermNormalized)
+            {
+                return 100;
+            }
+
+            if (fileNameNormalized.Contains(searchTermNormalized))
+            {
+                return 94;
+            }
+
+            if (searchTermNormalized.Contains(fileNameNormalized))
+            {
+                return 90;
+            }
+
+            var score = (int)Math.Round(fileNameNormalized.GetJaroWinklerSimilarityIgnoreCase(searchTermNormalized) * 100);
+            if (fileNameNormalized.MatchesAllWords(searchTermNormalized))
+            {
+                score = Math.Max(score, 84);
+            }
+
+            return score;
+        }
+
+        private static string NormalizeMatchValue(string value)
+        {
+            if (value.IsNullOrWhiteSpace())
+            {
+                return string.Empty;
+            }
+
+            var name = Path.GetFileNameWithoutExtension(value);
+            name = Regex.Replace(name, @"\s*[\(\[].*?[\)\]]\s*$", " ");
+            return name.NormalizeGameName().Satinize();
+        }
+
+        private void NotifyMissingCredentials(bool isBackgroundDownload)
+        {
+            if (isBackgroundDownload || _missingCredentialsNotificationShown)
+            {
+                return;
+            }
+
+            _missingCredentialsNotificationShown = true;
+            _playniteApi.Notifications.Add(new NotificationMessage(
+                "ExtraMetadataLoaderEmuMoviesCredentialsMissing",
+                ResourceProvider.GetString("LOCExtra_Metadata_Loader_NotificationMessageEmuMoviesCredentialsMissing"),
+                NotificationType.Error));
+        }
+    }
+}

--- a/source/Generic/ExtraMetadataLoader/MetadataProviders/IVideoProvider.cs
+++ b/source/Generic/ExtraMetadataLoader/MetadataProviders/IVideoProvider.cs
@@ -27,15 +27,25 @@ namespace ExtraMetadataLoader.MetadataProviders
         }
     }
 
+    public enum VideoType
+    {
+        Trailer,
+        Microtrailer
+    }
+
     public class VideoDownloadOptions
     {
         public string DownloadPath { get; private set; }
         public bool IsBackgroundDownload { get; private set; }
+        public VideoType VideoType { get; private set; }
+        public bool SelectAutomatically { get; private set; }
 
-        public VideoDownloadOptions (string downloadPath, bool isBackgroundDownload)
+        public VideoDownloadOptions(string downloadPath, bool isBackgroundDownload, VideoType videoType = VideoType.Trailer, bool selectAutomatically = false)
         {
             DownloadPath = downloadPath;
             IsBackgroundDownload = isBackgroundDownload;
+            VideoType = videoType;
+            SelectAutomatically = selectAutomatically;
         }
     }
 

--- a/source/Generic/ExtraMetadataLoader/MetadataProviders/Steam/SteamMetadataProvider.cs
+++ b/source/Generic/ExtraMetadataLoader/MetadataProviders/Steam/SteamMetadataProvider.cs
@@ -107,7 +107,7 @@ namespace ExtraMetadataLoader.MetadataProviders
                 videoUrl = string.Format(_steamMicrotrailerUrlTemplate, steamAppDetails.data.Movies[0].Id);
             }
 
-            var videoResult = VideoResult.FromFilePath(videoUrl);
+            var videoResult = VideoResult.FromUrl(videoUrl);
             return Result<VideoResult>.Success(videoResult);
 
 

--- a/source/Generic/ExtraMetadataLoader/Services/MetadataDownloadService.cs
+++ b/source/Generic/ExtraMetadataLoader/Services/MetadataDownloadService.cs
@@ -8,6 +8,7 @@ using Playnite.SDK.Models;
 using PluginsCommon;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -55,6 +56,26 @@ namespace ExtraMetadataLoader.Services
 
         public async Task<bool> DownloadLogoAsync(Game game, bool isBackgroundDownload, bool overwrite, CancellationToken cancelToken)
         {
+            return await DownloadLogoAsync(_logoProviders, game, isBackgroundDownload, overwrite, cancelToken);
+        }
+
+        public async Task<bool> DownloadLogoAsync(Game game, bool isBackgroundDownload, CancellationToken cancelToken)
+        {
+            return await DownloadLogoAsync(game, isBackgroundDownload, false, cancelToken);
+        }
+
+        public async Task<bool> DownloadLogoAsync(ILogoProvider logoProvider, Game game, bool isBackgroundDownload, bool overwrite, CancellationToken cancelToken)
+        {
+            if (logoProvider is null)
+            {
+                return false;
+            }
+
+            return await DownloadLogoAsync(new[] { logoProvider }, game, isBackgroundDownload, overwrite, cancelToken);
+        }
+
+        private async Task<bool> DownloadLogoAsync(IEnumerable<ILogoProvider> logoProviders, Game game, bool isBackgroundDownload, bool overwrite, CancellationToken cancelToken)
+        {
             var logoDownloadPath = ExtraMetadataHelper.GetGameLogoPath(game);
             if (!overwrite && FileSystem.FileExists(logoDownloadPath))
             {
@@ -62,7 +83,7 @@ namespace ExtraMetadataLoader.Services
             }
 
             var downloadOptions = new LogoDownloadOptions(isBackgroundDownload);            
-            foreach (var provider in _logoProviders)
+            foreach (var provider in logoProviders)
             {
                 try
                 {
@@ -84,7 +105,7 @@ namespace ExtraMetadataLoader.Services
                     }
 
                     OnLogoUpdated(game);
-                    break;
+                    return true;
                 }
                 catch (Exception ex)
                 {
@@ -123,14 +144,29 @@ namespace ExtraMetadataLoader.Services
 
         public async Task<bool> DownloadVideoAsync(Game game, bool isBackgroundDownload, bool overwrite, CancellationToken cancelToken)
         {
+            return await DownloadVideoAsync(_videoProviders, game, isBackgroundDownload, overwrite, cancelToken);
+        }
+
+        public async Task<bool> DownloadVideoAsync(IVideoProvider videoProvider, Game game, bool isBackgroundDownload, bool overwrite, CancellationToken cancelToken, bool selectAutomatically = false)
+        {
+            if (videoProvider is null)
+            {
+                return false;
+            }
+
+            return await DownloadVideoAsync(new[] { videoProvider }, game, isBackgroundDownload, overwrite, cancelToken, selectAutomatically);
+        }
+
+        private async Task<bool> DownloadVideoAsync(IEnumerable<IVideoProvider> videoProviders, Game game, bool isBackgroundDownload, bool overwrite, CancellationToken cancelToken, bool selectAutomatically = false)
+        {
             var videoDownloadPath = ExtraMetadataHelper.GetGameVideoPath(game);
             if (!overwrite && FileSystem.FileExists(videoDownloadPath))
             {
                 return true;
             }
 
-            var downloadOptions = new VideoDownloadOptions(videoDownloadPath, isBackgroundDownload);
-            foreach (var provider in _videoProviders)
+            var downloadOptions = new VideoDownloadOptions(videoDownloadPath, isBackgroundDownload, VideoType.Trailer, selectAutomatically);
+            foreach (var provider in videoProviders)
             {
                 try
                 {
@@ -141,9 +177,13 @@ namespace ExtraMetadataLoader.Services
                     }
 
                     var result = getResult.Value;
+                    string videoSourcePath;
+                    var deleteSource = false;
                     if (result.IsUrl)
                     {
-                        var downloadIsSuccess = await DownloadFile(result.Url, videoDownloadPath, cancelToken);
+                        videoSourcePath = Path.Combine(Path.GetTempPath(), $"ExtraMetadataLoader_MetadataVideo_{game.Id}_{Guid.NewGuid():N}.mp4");
+                        deleteSource = true;
+                        var downloadIsSuccess = await DownloadFile(result.Url, videoSourcePath, cancelToken);
                         if (!downloadIsSuccess)
                         {
                             continue;
@@ -153,9 +193,14 @@ namespace ExtraMetadataLoader.Services
                     {
                         continue;
                     }
+                    else
+                    {
+                        videoSourcePath = result.FilePath;
+                        deleteSource = true;
+                    }
 
-                    var videoSourcePath = result.IsUrl ? videoDownloadPath : result.FilePath;
-                    var processingIsSuccess = _videoProcessor.ProcessVideo(videoSourcePath, videoDownloadPath, false, true);
+                    ExtraMetadataHelper.GetGameVideoPath(game, true);
+                    var processingIsSuccess = _videoProcessor.ProcessVideo(videoSourcePath, videoDownloadPath, false, deleteSource);
                     if (!processingIsSuccess)
                     {
                         FileSystem.DeleteFile(videoSourcePath);
@@ -163,7 +208,7 @@ namespace ExtraMetadataLoader.Services
                     }
 
                     OnVideoUpdated(game);
-                    break;
+                    return true;
                 }
                 catch (Exception ex)
                 {

--- a/source/Generic/ExtraMetadataLoader/Services/VideosDownloader.cs
+++ b/source/Generic/ExtraMetadataLoader/Services/VideosDownloader.cs
@@ -1,5 +1,7 @@
 ﻿using ExtraMetadataLoader.Helpers;
 using ExtraMetadataLoader.Models;
+using ExtraMetadataLoader.MetadataProviders;
+using ExtraMetadataLoader.VideosProcessor;
 using Newtonsoft.Json;
 using Playnite.SDK;
 using Playnite.SDK.Models;
@@ -23,6 +25,7 @@ namespace ExtraMetadataLoader.Services
         private readonly IPlayniteAPI playniteApi;
         private static readonly ILogger logger = LogManager.GetLogger();
         private readonly ExtraMetadataLoaderSettings settings;
+        private readonly VideoProcessor videoProcessor;
         
         private readonly string tempDownloadPath = Path.Combine(Path.GetTempPath(), "VideoTemp.mp4");
 
@@ -30,21 +33,71 @@ namespace ExtraMetadataLoader.Services
         {
             this.playniteApi = playniteApi;
             this.settings = settings;
+            videoProcessor = new VideoProcessor(playniteApi, logger, settings);
         }
 
         public bool DownloadSteamVideo(Game game, bool overwrite, bool isBackgroundDownload, CancellationToken cancelToken, bool downloadVideo = false, bool downloadVideoMicro = false)
         {
+            var success = false;
+            if (downloadVideo)
+            {
+                success |= DownloadSteamVideo(game, overwrite, isBackgroundDownload, cancelToken, VideoType.Trailer);
+            }
 
+            if (downloadVideoMicro)
+            {
+                success |= DownloadSteamVideo(game, overwrite, isBackgroundDownload, cancelToken, VideoType.Microtrailer);
+            }
+
+            return success;
+        }
+
+        private bool DownloadSteamVideo(Game game, bool overwrite, bool isBackgroundDownload, CancellationToken cancelToken, VideoType videoType)
+        {
+            var videoPath = videoType == VideoType.Trailer
+                ? ExtraMetadataHelper.GetGameVideoPath(game, true)
+                : ExtraMetadataHelper.GetGameVideoMicroPath(game, true);
+
+            if (FileSystem.FileExists(videoPath) && !overwrite)
+            {
+                return true;
+            }
+
+            var steamProvider = new SteamMetadataProvider(playniteApi, settings);
+            var getResult = steamProvider.GetVideo(game, new VideoDownloadOptions(videoPath, isBackgroundDownload, videoType), cancelToken);
+            if (!getResult.IsSuccess || getResult.Value is null)
+            {
+                return false;
+            }
+
+            var videoSourcePath = getResult.Value.FilePath;
+            var deleteSource = false;
+            if (getResult.Value.IsUrl)
+            {
+                videoSourcePath = Path.Combine(Path.GetTempPath(), $"ExtraMetadataLoader_Steam_{game.Id}_{videoType}_{Guid.NewGuid():N}.mp4");
+                deleteSource = true;
+                if (!DownloadFile(getResult.Value.Url, videoSourcePath, cancelToken))
+                {
+                    return false;
+                }
+            }
+
+            if (videoSourcePath.IsNullOrWhiteSpace() || !FileSystem.FileExists(videoSourcePath))
+            {
+                return false;
+            }
+
+            return videoProcessor.ProcessVideo(videoSourcePath, videoPath, false, deleteSource);
         }
 
         public bool SelectedDialogFileToVideo(Game game)
         {
             logger.Debug($"SelectedDialogFileToVideo starting for game {game.Name}");
-            var videoPath = extraMetadataHelper.GetGameVideoPath(game, true);
+            var videoPath = ExtraMetadataHelper.GetGameVideoPath(game, true);
             var selectedVideoPath = playniteApi.Dialogs.SelectFile("Video file|*.mp4;*.avi;*.mkv;*.webm;*.flv;*.wmv;*.mov;*.m4v");
             if (!selectedVideoPath.IsNullOrEmpty())
             {
-                return ProcessVideo(selectedVideoPath, videoPath, true, false);
+                return videoProcessor.ProcessVideo(selectedVideoPath, videoPath, true, false);
             }
             else
             {
@@ -54,11 +107,11 @@ namespace ExtraMetadataLoader.Services
 
         public bool DownloadYoutubeVideoById(Game game, string videoId, bool overwrite)
         {
-            var youtubeDlPath = extraMetadataHelper.ExpandVariables(game, settings.YoutubeDlPath);
-            var ffmpegPath = extraMetadataHelper.ExpandVariables(game, settings.FfmpegPath);
-            var youtubeCookiesPath = extraMetadataHelper.ExpandVariables(game, settings.YoutubeCookiesPath);
+            var youtubeDlPath = ExtraMetadataHelper.ExpandVariables(game, settings.YoutubeDlPath);
+            var ffmpegPath = ExtraMetadataHelper.ExpandVariables(game, settings.FfmpegPath);
+            var youtubeCookiesPath = ExtraMetadataHelper.ExpandVariables(game, settings.YoutubeCookiesPath);
 
-            var videoPath = extraMetadataHelper.GetGameVideoPath(game, true);
+            var videoPath = ExtraMetadataHelper.GetGameVideoPath(game, true);
             if (FileSystem.FileExists(videoPath) && !overwrite)
             {
                 return false;
@@ -82,8 +135,24 @@ namespace ExtraMetadataLoader.Services
             }
             else
             {
-                return ProcessVideo(tempDownloadPath, videoPath, false, false);
+                return videoProcessor.ProcessVideo(tempDownloadPath, videoPath, false, true);
             }
+        }
+
+        private bool DownloadFile(string url, string downloadPath, CancellationToken cancelToken)
+        {
+            FileSystem.DeleteFile(downloadPath);
+            var request = HttpRequestFactory.GetHttpFileRequest()
+                .WithUrl(url)
+                .WithDownloadTo(downloadPath);
+
+            var downloadFileResult = request.DownloadFileAsync(cancelToken).GetAwaiter().GetResult();
+            return downloadFileResult.IsSuccess && FileSystem.FileExists(downloadPath);
+        }
+
+        public bool ConvertVideoToMicro(Game game, bool overwrite)
+        {
+            return videoProcessor.ConvertVideoToMicro(game, overwrite);
         }
 
     }


### PR DESCRIPTION
## Summary
- Adds EmuMovies as a full video trailer provider for Extra Metadata Loader.
- Supports encrypted EmuMovies credential storage, credential testing, selectable video quality, and optional HD/HQ/SQ fallback.
- Adds an EmuMovies video download context-menu action with automatic or manual match selection.
- Discovers EmuMovies FTP platform directories dynamically and retries transient directory listing failures.
- Adds only the new English localization strings in en_US.xaml, matching existing upstream localization guidance.

## Validation
- Built source/Generic/ExtraMetadataLoader/ExtraMetadataLoader.sln in Release.
- Packaged with Playnite Toolbox.
- Manually tested EmuMovies login, credential test/save, settings UI, single-game video downloads, multi-game video downloads, automatic selection, manual chooser selection, and HD/HQ/SQ fallback.
