### PR TITLE
Fix GameRelations shelf UI stutter

### DIFF
--- a/source/Generic/GameRelations/GameRelations.csproj
+++ b/source/Generic/GameRelations/GameRelations.csproj
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Playnite.SDK, Version=6.9.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PlayniteSDK.6.9.0\lib\net462\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK, Version=6.10.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PlayniteSDK.6.10.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -108,6 +108,7 @@
     <Compile Include="MatchedGamesUtilities.cs" />
     <Compile Include="Interfaces\IGameRelationsControlSettings.cs" />
     <Compile Include="Models\GameRelationsControlSettings.cs" />
+    <Compile Include="Models\GameRelationSnapshot.cs" />
     <Compile Include="Models\MatchedGameWrapper.cs" />
     <Compile Include="Models\SimilarGamesControlSettings.cs" />
     <Compile Include="PlayniteControls\GameRelationsBase.xaml.cs">

--- a/source/Generic/GameRelations/MatchedGamesUtilities.cs
+++ b/source/Generic/GameRelations/MatchedGamesUtilities.cs
@@ -1,12 +1,9 @@
 ﻿using GameRelations.Models;
 using Playnite.SDK;
-using Playnite.SDK.Models;
 using PluginsCommon;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Media.Imaging;
@@ -16,10 +13,9 @@ namespace GameRelations
 {
     public static class MatchedGamesUtilities
     {
-        private static readonly IPlayniteAPI _playniteApi = API.Instance;
         private static readonly ILogger _logger = LogManager.GetLogger();
         private static readonly CacheManager<string, BitmapImage> _imagesCacheManager = new CacheManager<string, BitmapImage>().WithItemLifetime(TimeSpan.FromSeconds(30));
-        private static readonly BitmapImage _defaultCover = new BitmapImage(new Uri("/GameRelations;component/Resources/DefaultCover.png", UriKind.Relative));
+        private static readonly BitmapImage _defaultCover = GetDefaultCover();
         private static SemaphoreSlim _bulkGetGamesWrappersLimiter = new SemaphoreSlim(1);
 
         public static BitmapImage CreateResizedBitmapImageFromPath(string filePath, int maxWidth, int maxHeight)
@@ -50,12 +46,26 @@ namespace GameRelations
             return bitmapImage;
         }
 
-        public static async Task<IEnumerable<MatchedGameWrapper>> GetGamesWrappersAsync(IEnumerable<Game> games, GameRelationsSettings settings)
+        private static BitmapImage GetDefaultCover()
         {
-            await _bulkGetGamesWrappersLimiter.WaitAsync();
+            var bitmapImage = new BitmapImage(new Uri("/GameRelations;component/Resources/DefaultCover.png", UriKind.Relative));
+            bitmapImage.Freeze();
+            return bitmapImage;
+        }
+
+        internal static async Task<List<MatchedGameWrapper>> GetGamesWrappersAsync(IEnumerable<GameRelationSnapshot> games, int coverHeight, CancellationToken cancellationToken)
+        {
+            await _bulkGetGamesWrappersLimiter.WaitAsync(cancellationToken);
             try
             {
-                return games.Select(g => GetGameWrapper(g, settings));
+                var gameWrappers = new List<MatchedGameWrapper>();
+                foreach (var game in games)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    gameWrappers.Add(GetGameWrapper(game, coverHeight));
+                }
+
+                return gameWrappers;
             }
             finally
             {
@@ -63,25 +73,23 @@ namespace GameRelations
             }
         }
 
-        public static MatchedGameWrapper GetGameWrapper(Game game, GameRelationsSettings settings)
+        private static MatchedGameWrapper GetGameWrapper(GameRelationSnapshot game, int coverHeight)
         {
-            var bitmapImage = GetGameCoverImage(game, settings);
-            return new MatchedGameWrapper(game, bitmapImage);
+            var bitmapImage = GetGameCoverImage(game.CoverImagePath, coverHeight);
+            return new MatchedGameWrapper(game.Game, bitmapImage);
         }
 
-        private static BitmapImage GetGameCoverImage(Game game, GameRelationsSettings settings)
+        private static BitmapImage GetGameCoverImage(string imagePath, int coverHeight)
         {
-            if (game.CoverImage.IsNullOrEmpty())
+            if (imagePath.IsNullOrEmpty())
             {
                 return _defaultCover;
             }
 
-            var imagePath = _playniteApi.Database.GetFullFilePath(game.CoverImage);
             if (FileSystem.FileExists(imagePath))
             {
                 try
                 {
-                    var coverHeight = settings.CoversHeight;
                     var cacheKey = $"{imagePath}_{coverHeight}";
                     if (_imagesCacheManager.TryGetValue(cacheKey, out var cachedBitmap))
                     {

--- a/source/Generic/GameRelations/Models/GameRelationSnapshot.cs
+++ b/source/Generic/GameRelations/Models/GameRelationSnapshot.cs
@@ -1,0 +1,59 @@
+using Playnite.SDK.Models;
+using System;
+using System.Collections.Generic;
+
+namespace GameRelations.Models
+{
+    internal sealed class GameRelationSnapshot
+    {
+        public Game Game { get; set; }
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string SortingName { get; set; }
+        public bool Hidden { get; set; }
+        public bool IsInstalled { get; set; }
+        public string CoverImagePath { get; set; }
+        public List<Guid> TagIds { get; set; }
+        public List<Guid> GenreIds { get; set; }
+        public List<Guid> CategoryIds { get; set; }
+        public List<Guid> SeriesIds { get; set; }
+        public List<GameRelationValueSnapshot> Series { get; set; }
+        public List<GameRelationValueSnapshot> Developers { get; set; }
+        public List<GameRelationValueSnapshot> Publishers { get; set; }
+
+        public string SortName
+        {
+            get
+            {
+                return string.IsNullOrEmpty(SortingName) ? Name : SortingName;
+            }
+        }
+    }
+
+    internal sealed class GameRelationValueSnapshot
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    internal sealed class GameRelationsUpdateResult
+    {
+        public List<MatchedGameWrapper> GameWrappers { get; set; }
+    }
+
+    internal sealed class GameRelationsUpdateSettings
+    {
+        public int MaxItems { get; set; }
+        public bool DisplayOnlyInstalled { get; set; }
+        public int CoversHeight { get; set; }
+        public object MatchingSettings { get; set; }
+    }
+
+    internal sealed class SimilarGamesMatchingSettings
+    {
+        public HashSet<Guid> TagsToIgnore { get; set; }
+        public HashSet<Guid> CategoriesToIgnore { get; set; }
+        public HashSet<Guid> GenresToIgnore { get; set; }
+        public bool ExcludeGamesSameSeries { get; set; }
+    }
+}

--- a/source/Generic/GameRelations/PlayniteControls/GameRelationsBase.xaml.cs
+++ b/source/Generic/GameRelations/PlayniteControls/GameRelationsBase.xaml.cs
@@ -9,19 +9,13 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using System.Windows.Threading;
-using TemporaryCache;
 
 namespace GameRelations.PlayniteControls
 {
@@ -36,6 +30,8 @@ namespace GameRelations.PlayniteControls
         private readonly DispatcherTimer _updateDataTimer;
         private readonly DesktopView _activeViewAtCreation;
         private static readonly ILogger _logger = LogManager.GetLogger();
+        private CancellationTokenSource _updateDataCancellationTokenSource;
+        private long _updateDataVersion;
         public event PropertyChangedEventHandler PropertyChanged;
         protected void OnPropertyChanged([CallerMemberName] string name = null)
         {
@@ -107,6 +103,7 @@ namespace GameRelations.PlayniteControls
         public override void GameContextChanged(Game oldContext, Game newContext)
         {
             _updateDataTimer.Stop();
+            CancelPendingUpdate();
             if (PlayniteApi.ApplicationInfo.Mode == ApplicationMode.Desktop &&
                 _activeViewAtCreation != PlayniteApi.MainView.ActiveDesktopView)
             {
@@ -134,9 +131,52 @@ namespace GameRelations.PlayniteControls
             ControlSettings.IsVisible = true;
         }
 
-        public virtual IEnumerable<Game> GetMatchingGames(Game game)
+        internal virtual object CreateMatchingSettingsSnapshot()
         {
-            return Enumerable.Empty<Game>();
+            return null;
+        }
+
+        internal virtual IEnumerable<GameRelationSnapshot> GetMatchingGames(GameRelationSnapshot game, List<GameRelationSnapshot> libraryGames, object matchingSettings)
+        {
+            return Enumerable.Empty<GameRelationSnapshot>();
+        }
+
+        internal static IEnumerable<GameRelationSnapshot> GetMatchingGamesByRelation(
+            GameRelationSnapshot game,
+            List<GameRelationSnapshot> libraryGames,
+            Func<GameRelationSnapshot, List<GameRelationValueSnapshot>> relationSelector)
+        {
+            var sourceRelations = relationSelector(game);
+            if (!sourceRelations.HasItems())
+            {
+                return Enumerable.Empty<GameRelationSnapshot>();
+            }
+
+            var sourceHashSet = sourceRelations.Select(x => x.Id).ToHashSet();
+            var similarGamesDict = new Dictionary<GameRelationSnapshot, string>();
+            foreach (var otherGame in libraryGames)
+            {
+                if (otherGame.Id == game.Id)
+                {
+                    continue;
+                }
+
+                if (!game.Hidden && otherGame.Hidden)
+                {
+                    continue;
+                }
+
+                var commonItem = relationSelector(otherGame).FirstOrDefault(x => sourceHashSet.Contains(x.Id));
+                if (commonItem != null)
+                {
+                    similarGamesDict.Add(otherGame, commonItem.Name);
+                }
+            }
+
+            return similarGamesDict
+                .OrderBy(pair => pair.Value)
+                .ThenBy(x => x.Key.SortName)
+                .Select(x => x.Key);
         }
 
         public async Task UpdateDataAsync()
@@ -147,25 +187,143 @@ namespace GameRelations.PlayniteControls
                 return;
             }
 
-            var contextGame = GameContext;
-            var matchedGames = GetMatchingGames(contextGame);
-            if (GameContext is null || GameContext.Id != contextGame.Id || !matchedGames.HasItems())
+            CancelPendingUpdate();
+            var updateVersion = Interlocked.Increment(ref _updateDataVersion);
+            var updateCancellationTokenSource = new CancellationTokenSource();
+            _updateDataCancellationTokenSource = updateCancellationTokenSource;
+            var cancellationToken = updateCancellationTokenSource.Token;
+            var controlName = GetType().Name;
+
+            GameRelationSnapshot contextGame;
+            List<GameRelationSnapshot> librarySnapshot;
+            GameRelationsUpdateSettings updateSettings;
+            try
             {
+                contextGame = CreateGameSnapshot(GameContext);
+                librarySnapshot = PlayniteApi.Database.Games.Select(CreateGameSnapshot).ToList();
+                updateSettings = new GameRelationsUpdateSettings
+                {
+                    MaxItems = ControlSettings.MaxItems,
+                    DisplayOnlyInstalled = ControlSettings.DisplayOnlyInstalled,
+                    CoversHeight = Settings.CoversHeight,
+                    MatchingSettings = CreateMatchingSettingsSnapshot()
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, $"GameRelations {controlName}: Failed to create game relation snapshot.");
+                ClearCompletedUpdate(updateCancellationTokenSource);
                 return;
             }
 
-            var filteredGames = matchedGames
-                .Where(g => g.IsInstalled || !ControlSettings.DisplayOnlyInstalled)
-                .Take(ControlSettings.MaxItems);
-
-            var gameWrappers = await MatchedGamesUtilities.GetGamesWrappersAsync(filteredGames, Settings);
-            if (GameContext is null || GameContext.Id != contextGame.Id || !gameWrappers.HasItems())
+            var contextGameId = contextGame.Id;
+            GameRelationsUpdateResult updateResult;
+            try
             {
+                updateResult = await Task.Run(async () =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var matchedGames = GetMatchingGames(contextGame, librarySnapshot, updateSettings.MatchingSettings).ToList();
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var filteredGames = matchedGames
+                        .Where(g => g.IsInstalled || !updateSettings.DisplayOnlyInstalled)
+                        .Take(updateSettings.MaxItems)
+                        .ToList();
+
+                    var gameWrappers = await MatchedGamesUtilities.GetGamesWrappersAsync(filteredGames, updateSettings.CoversHeight, cancellationToken);
+
+                    return new GameRelationsUpdateResult
+                    {
+                        GameWrappers = gameWrappers
+                    };
+                }, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                ClearCompletedUpdate(updateCancellationTokenSource);
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, $"GameRelations {controlName}: Failed to prepare related games for {contextGame.Name}.");
+                ClearCompletedUpdate(updateCancellationTokenSource);
                 return;
             }
 
-            MatchedGames = gameWrappers;
+            if (cancellationToken.IsCancellationRequested ||
+                updateVersion != Interlocked.Read(ref _updateDataVersion) ||
+                GameContext is null ||
+                GameContext.Id != contextGameId ||
+                !updateResult.GameWrappers.HasItems())
+            {
+                ClearCompletedUpdate(updateCancellationTokenSource);
+                return;
+            }
+
+            MatchedGames = updateResult.GameWrappers;
             DisplayControl();
+            ClearCompletedUpdate(updateCancellationTokenSource);
+        }
+
+        private void CancelPendingUpdate()
+        {
+            Interlocked.Increment(ref _updateDataVersion);
+            var cancellationTokenSource = _updateDataCancellationTokenSource;
+            if (cancellationTokenSource is null)
+            {
+                return;
+            }
+
+            _updateDataCancellationTokenSource = null;
+            cancellationTokenSource.Cancel();
+        }
+
+        private void ClearCompletedUpdate(CancellationTokenSource updateCancellationTokenSource)
+        {
+            if (_updateDataCancellationTokenSource != updateCancellationTokenSource)
+            {
+                updateCancellationTokenSource.Dispose();
+                return;
+            }
+
+            _updateDataCancellationTokenSource = null;
+            updateCancellationTokenSource.Dispose();
+        }
+
+        private GameRelationSnapshot CreateGameSnapshot(Game game)
+        {
+            return new GameRelationSnapshot
+            {
+                Game = game,
+                Id = game.Id,
+                Name = game.Name,
+                SortingName = game.SortingName,
+                Hidden = game.Hidden,
+                IsInstalled = game.IsInstalled,
+                CoverImagePath = game.CoverImage.IsNullOrEmpty() ? null : PlayniteApi.Database.GetFullFilePath(game.CoverImage),
+                TagIds = game.TagIds?.ToList() ?? new List<Guid>(),
+                GenreIds = game.GenreIds?.ToList() ?? new List<Guid>(),
+                CategoryIds = game.CategoryIds?.ToList() ?? new List<Guid>(),
+                SeriesIds = game.SeriesIds?.ToList() ?? new List<Guid>(),
+                Series = SnapshotRelationValues(game.Series),
+                Developers = SnapshotRelationValues(game.Developers),
+                Publishers = SnapshotRelationValues(game.Publishers)
+            };
+        }
+
+        private static List<GameRelationValueSnapshot> SnapshotRelationValues<T>(IEnumerable<T> values) where T : DatabaseObject
+        {
+            if (values is null)
+            {
+                return new List<GameRelationValueSnapshot>();
+            }
+
+            return values.Select(x => new GameRelationValueSnapshot
+            {
+                Id = x.Id,
+                Name = x.Name
+            }).ToList();
         }
 
         private void ScrollGamesContainerToStart()
@@ -179,42 +337,6 @@ namespace GameRelations.PlayniteControls
 
                 gamesScrollViewer?.ScrollToHome();
             }
-        }
-
-        /// <summary>
-        /// Calculates the match value between a list of items and a HashSet by determining the percentage of common elements.
-        /// </summary>
-        /// <param name="listToMatch">The list of items to compare.</param>
-        /// <param name="hashSet">The HashSet to compare against.</param>
-        /// <returns>A match value between 0 and 1 representing the percentage of common elements.</returns>
-        protected static decimal CalculateListHashSetMatchPercentage<T>(IEnumerable<T> listToMatch, HashSet<T> hashSet)
-        {
-            if (listToMatch is null || !listToMatch.Any())
-            {
-                if (hashSet.Count == 0)
-                {
-                    return 1;
-                }
-                else
-                {
-                    return 0;
-                }
-            }
-
-            if (hashSet.Count == 0)
-            {
-                return 0;
-            }
-
-            var commonCount = listToMatch.Count(item => hashSet.Contains(item));
-            if (commonCount == 0)
-            {
-                return 0;
-            }
-
-            // Rounding is done to prevent errors when doing arithmetic operations
-            var matchPercent = Math.Round(commonCount / (decimal)Math.Max(listToMatch.Count(), hashSet.Count), 3); 
-            return matchPercent;
         }
 
         /// <summary>
@@ -248,30 +370,6 @@ namespace GameRelations.PlayniteControls
             // Rounding is done to prevent errors when doing arithmetic operations
             var similarity = Math.Round((double)commonCount / uniqueCount, 3);
             return similarity;
-        }
-
-        /// <summary>
-        /// Checks if there is any common item between a list and a HashSet.
-        /// </summary>
-        /// <param name="listToMatch">The list to check for common items.</param>
-        /// <param name="hashSet">The HashSet to check against.</param>
-        /// <returns>Returns the common item if found, default value otherwise</returns>
-        protected static T GetAnyCommonItem<T>(List<T> listToMatch, HashSet<T> hashSet)
-        {
-            if (listToMatch is null || listToMatch.Count == 0 || hashSet.Count == 0)
-            {
-                return default;
-            }
-
-            foreach (var item in listToMatch)
-            {
-                if (hashSet.Contains(item))
-                {
-                    return item;
-                }
-            }
-
-            return default;
         }
 
         /// <summary>

--- a/source/Generic/GameRelations/PlayniteControls/SameDeveloperControl.cs
+++ b/source/Generic/GameRelations/PlayniteControls/SameDeveloperControl.cs
@@ -1,13 +1,7 @@
-﻿using GameRelations.Interfaces;
+using GameRelations.Interfaces;
+using GameRelations.Models;
 using Playnite.SDK;
-using Playnite.SDK.Models;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Media.Imaging;
-using TemporaryCache;
 
 namespace GameRelations.PlayniteControls
 {
@@ -19,40 +13,9 @@ namespace GameRelations.PlayniteControls
 
         }
 
-        public override IEnumerable<Game> GetMatchingGames(Game game)
+        internal override IEnumerable<GameRelationSnapshot> GetMatchingGames(GameRelationSnapshot game, List<GameRelationSnapshot> libraryGames, object matchingSettings)
         {
-            if (!game.Developers.HasItems())
-            {
-                return Enumerable.Empty<Game>();
-            }
-            
-            var sourceHashSet = game.Developers.ToHashSet();
-            var similarGamesDict = new Dictionary<Game, string>();
-            foreach (var otherGame in PlayniteApi.Database.Games)
-            {
-                if (otherGame.Id == game.Id)
-                {
-                    continue;
-                }
-
-                if (!game.Hidden && otherGame.Hidden)
-                {
-                    continue;
-                }
-
-                var commonItem = GetAnyCommonItem(otherGame.Developers, sourceHashSet);
-                if (commonItem != default(Company))
-                {
-                    similarGamesDict.Add(otherGame, commonItem.Name);
-                }
-            }
-
-            var similarGames = similarGamesDict
-                .OrderBy(pair => pair.Value)
-                .ThenBy(x => !x.Key.SortingName.IsNullOrEmpty() ? x.Key.SortingName : x.Key.Name)
-                .Select(x => x.Key);
-
-            return similarGames;
+            return GetMatchingGamesByRelation(game, libraryGames, x => x.Developers);
         }
     }
 }

--- a/source/Generic/GameRelations/PlayniteControls/SamePublisherControl.cs
+++ b/source/Generic/GameRelations/PlayniteControls/SamePublisherControl.cs
@@ -1,13 +1,7 @@
-﻿using GameRelations.Interfaces;
+using GameRelations.Interfaces;
+using GameRelations.Models;
 using Playnite.SDK;
-using Playnite.SDK.Models;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Media.Imaging;
-using TemporaryCache;
 
 namespace GameRelations.PlayniteControls
 {
@@ -19,40 +13,9 @@ namespace GameRelations.PlayniteControls
 
         }
 
-        public override IEnumerable<Game> GetMatchingGames(Game game)
+        internal override IEnumerable<GameRelationSnapshot> GetMatchingGames(GameRelationSnapshot game, List<GameRelationSnapshot> libraryGames, object matchingSettings)
         {
-            if (!game.Publishers.HasItems())
-            {
-                return Enumerable.Empty<Game>();
-            }
-            
-            var sourceHashSet = game.Publishers.ToHashSet();
-            var similarGamesDict = new Dictionary<Game, string>();
-            foreach (var otherGame in PlayniteApi.Database.Games)
-            {
-                if (otherGame.Id == game.Id)
-                {
-                    continue;
-                }
-
-                if (!game.Hidden && otherGame.Hidden)
-                {
-                    continue;
-                }
-
-                var commonItem = GetAnyCommonItem(otherGame.Publishers, sourceHashSet);
-                if (commonItem != default(Company))
-                {
-                    similarGamesDict.Add(otherGame, commonItem.Name);
-                }
-            }
-
-            var similarGames = similarGamesDict
-                .OrderBy(pair => pair.Value)
-                .ThenBy(x => !x.Key.SortingName.IsNullOrEmpty() ? x.Key.SortingName : x.Key.Name)
-                .Select(x => x.Key);
-
-            return similarGames;
+            return GetMatchingGamesByRelation(game, libraryGames, x => x.Publishers);
         }
     }
 }

--- a/source/Generic/GameRelations/PlayniteControls/SameSeriesControl.cs
+++ b/source/Generic/GameRelations/PlayniteControls/SameSeriesControl.cs
@@ -1,13 +1,7 @@
-﻿using GameRelations.Interfaces;
+using GameRelations.Interfaces;
+using GameRelations.Models;
 using Playnite.SDK;
-using Playnite.SDK.Models;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Media.Imaging;
-using TemporaryCache;
 
 namespace GameRelations.PlayniteControls
 {
@@ -19,40 +13,9 @@ namespace GameRelations.PlayniteControls
 
         }
 
-        public override IEnumerable<Game> GetMatchingGames(Game game)
+        internal override IEnumerable<GameRelationSnapshot> GetMatchingGames(GameRelationSnapshot game, List<GameRelationSnapshot> libraryGames, object matchingSettings)
         {
-            if (!game.Series.HasItems())
-            {
-                return Enumerable.Empty<Game>();
-            }
-            
-            var seriesHashSet = game.Series.ToHashSet();
-            var similarGamesDict = new Dictionary<Game, string>();
-            foreach (var otherGame in PlayniteApi.Database.Games)
-            {
-                if (otherGame.Id == game.Id)
-                {
-                    continue;
-                }
-
-                if (!game.Hidden && otherGame.Hidden)
-                {
-                    continue;
-                }
-
-                var commonItem = GetAnyCommonItem(otherGame.Series, seriesHashSet);
-                if (commonItem != default(Series))
-                {
-                    similarGamesDict.Add(otherGame, commonItem.Name);
-                }
-            }
-
-            var similarGames = similarGamesDict
-                .OrderBy(pair => pair.Value)
-                .ThenBy(x => !x.Key.SortingName.IsNullOrEmpty() ? x.Key.SortingName : x.Key.Name)
-                .Select(x => x.Key);
-
-            return similarGames;
+            return GetMatchingGamesByRelation(game, libraryGames, x => x.Series);
         }
 
     }

--- a/source/Generic/GameRelations/PlayniteControls/SimilarGamesControl.cs
+++ b/source/Generic/GameRelations/PlayniteControls/SimilarGamesControl.cs
@@ -1,14 +1,9 @@
 ﻿using GameRelations.Interfaces;
 using GameRelations.Models;
 using Playnite.SDK;
-using Playnite.SDK.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Media.Imaging;
-using TemporaryCache;
 
 namespace GameRelations.PlayniteControls
 {
@@ -30,17 +25,28 @@ namespace GameRelations.PlayniteControls
             };
         }
 
-        public override IEnumerable<Game> GetMatchingGames(Game game)
+        internal override object CreateMatchingSettingsSnapshot()
         {
-            var tagsSet = GetItemsNotInHashSet(game.TagIds, _controlSettings.TagsToIgnore).ToHashSet();
-            var genresSet = GetItemsNotInHashSet(game.GenreIds, _controlSettings.GenresToIgnore).ToHashSet();
-            var categoriesSet = GetItemsNotInHashSet(game.CategoryIds, _controlSettings.CategoriesToIgnore).ToHashSet();
+            return new SimilarGamesMatchingSettings
+            {
+                TagsToIgnore = _controlSettings.TagsToIgnore.ToHashSet(),
+                CategoriesToIgnore = _controlSettings.CategoriesToIgnore.ToHashSet(),
+                GenresToIgnore = _controlSettings.GenresToIgnore.ToHashSet(),
+                ExcludeGamesSameSeries = _controlSettings.ExcludeGamesSameSeries
+            };
+        }
 
-            var seriesHashSet = game.SeriesIds?.ToHashSet() ?? new HashSet<Guid>();
+        internal override IEnumerable<GameRelationSnapshot> GetMatchingGames(GameRelationSnapshot game, List<GameRelationSnapshot> libraryGames, object matchingSettings)
+        {
+            var controlSettings = (SimilarGamesMatchingSettings)matchingSettings;
+            var tagsSet = GetItemsNotInHashSet(game.TagIds, controlSettings.TagsToIgnore).ToHashSet();
+            var genresSet = GetItemsNotInHashSet(game.GenreIds, controlSettings.GenresToIgnore).ToHashSet();
+            var categoriesSet = GetItemsNotInHashSet(game.CategoryIds, controlSettings.CategoriesToIgnore).ToHashSet();
+            var seriesHashSet = game.SeriesIds.ToHashSet();
 
             var minScoreThreshold = _propertiesWeights.Count * _minMatchValueFactor;
-            var similarityScores = new Dictionary<Game, double>();
-            foreach (var otherGame in PlayniteApi.Database.Games)
+            var similarityScores = new Dictionary<GameRelationSnapshot, double>();
+            foreach (var otherGame in libraryGames)
             {
                 if (otherGame.Id == game.Id)
                 {
@@ -52,14 +58,14 @@ namespace GameRelations.PlayniteControls
                     continue;
                 }
 
-                if (_controlSettings.ExcludeGamesSameSeries && HashSetContainsAnyItem(otherGame.SeriesIds, seriesHashSet))
+                if (controlSettings.ExcludeGamesSameSeries && HashSetContainsAnyItem(otherGame.SeriesIds, seriesHashSet))
                 {
                     continue;
                 }
 
-                var tagsScore = CalculateJaccardSimilarity(GetItemsNotInHashSet(otherGame.TagIds, _controlSettings.TagsToIgnore), tagsSet) * _propertiesWeights["tags"];
-                var genresScore = CalculateJaccardSimilarity(GetItemsNotInHashSet(otherGame.GenreIds, _controlSettings.GenresToIgnore), genresSet) * _propertiesWeights["genres"];
-                var categoriesScore = CalculateJaccardSimilarity(GetItemsNotInHashSet(otherGame.CategoryIds, _controlSettings.CategoriesToIgnore), categoriesSet) * _propertiesWeights["categories"];
+                var tagsScore = CalculateJaccardSimilarity(GetItemsNotInHashSet(otherGame.TagIds, controlSettings.TagsToIgnore), tagsSet) * _propertiesWeights["tags"];
+                var genresScore = CalculateJaccardSimilarity(GetItemsNotInHashSet(otherGame.GenreIds, controlSettings.GenresToIgnore), genresSet) * _propertiesWeights["genres"];
+                var categoriesScore = CalculateJaccardSimilarity(GetItemsNotInHashSet(otherGame.CategoryIds, controlSettings.CategoriesToIgnore), categoriesSet) * _propertiesWeights["categories"];
 
                 var finalScore = tagsScore + genresScore + categoriesScore;
                 if (finalScore >= minScoreThreshold)
@@ -68,10 +74,8 @@ namespace GameRelations.PlayniteControls
                 }
             }
 
-            var similarGames = similarityScores.OrderByDescending(pair => pair.Value)
+            return similarityScores.OrderByDescending(pair => pair.Value)
                 .Select(pair => pair.Key);
-
-            return similarGames;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Move GameRelations shelf matching and cover preparation off the WPF UI dispatcher
- Snapshot selected game, library, settings, and cover metadata before background processing
- Cancel stale shelf work when the selected game context changes
- Materialize matched game wrappers before applying them to controls
- Share Same Series, Same Developer and Same Publisher relation matching logic

## I have verified that: 
- [x] These changes work, by building the extension and testing. 
- [x] That the changes comply with the rules indicated in the repository. 
- [x] Pull request is targeting master branch.