### PR TITLE
JAST USA Library: Handle updated product response

### DIFF
--- a/source/Library/JastUsaLibrary/Services/JastUsaIntegration/Application/Services/JastUsaAccountClient.cs
+++ b/source/Library/JastUsaLibrary/Services/JastUsaIntegration/Application/Services/JastUsaAccountClient.cs
@@ -96,16 +96,20 @@ namespace JastUsaLibrary.JastUsaIntegration.Application.Services
 
             var products = await _apiClient.GetProductsAsync(token, cancellationToken);
             var gamesData = products.Select(product =>
-                new JastGameData(
-                    product.ProductName,
-                    product.ProductCode,
-                    product.GameId,
-                    product.Game.ApiRoute,
-                    product.Game.Translations.EnUs?.Id,
-                    product.Game.Translations.Ja?.Id,
-                    product.Game.Translations.ZhHans?.Id,
-                    product.Game.Translations.ZhHant?.Id
-                )).ToList();
+            {
+                var variant = product.Variant;
+                var game = product.Game ?? variant.Game;
+                return new JastGameData(
+                    variant.ProductName,
+                    variant.ProductCode,
+                    variant.GameId,
+                    game.ApiRoute,
+                    game.Translations.EnUs?.Id,
+                    game.Translations.Ja?.Id,
+                    game.Translations.ZhHans?.Id,
+                    game.Translations.ZhHant?.Id
+                );
+            }).ToList();
 
             return gamesData;
         }

--- a/source/Library/JastUsaLibrary/Services/JastUsaIntegration/Infrastructure/DTOs/GetGamesResponse.cs
+++ b/source/Library/JastUsaLibrary/Services/JastUsaIntegration/Infrastructure/DTOs/GetGamesResponse.cs
@@ -38,8 +38,8 @@ namespace JastUsaLibrary.Services.JastUsaIntegration.Infrastructure.DTOs
         [JsonProperty("@type")]
         public ProductType Type { get; set; }
 
-        [JsonProperty("variants")]
-        public Variant[] Variants { get; set; }
+        [JsonProperty("game")]
+        public Game Game { get; set; }
 
         [JsonProperty("variant")]
         public Variant Variant { get; set; }

--- a/source/Library/JastUsaLibrary/Services/JastUsaIntegration/Infrastructure/External/JastUsaApiClient.cs
+++ b/source/Library/JastUsaLibrary/Services/JastUsaIntegration/Infrastructure/External/JastUsaApiClient.cs
@@ -113,7 +113,7 @@ namespace JastUsaLibrary.JastUsaIntegration.Infrastructure.External
             return Serialization.FromJson<GameTranslationsResponse>(result.Content);
         }
 
-        public async Task<List<Variant>> GetProductsAsync(AuthenticationToken token, CancellationToken cancellationToken = default)
+        public async Task<List<Product>> GetProductsAsync(AuthenticationToken token, CancellationToken cancellationToken = default)
         {
             if (token is null || token.Token.IsNullOrWhiteSpace())
             {
@@ -126,7 +126,7 @@ namespace JastUsaLibrary.JastUsaIntegration.Infrastructure.External
                 ["Accept-Encoding"] = "utf-8"
             };
 
-            var products = new List<Variant>();
+            var products = new List<Product>();
             var page = 1;
             while (true)
             {
@@ -157,9 +157,9 @@ namespace JastUsaLibrary.JastUsaIntegration.Infrastructure.External
                 }
 
                 var response = Serialization.FromJson<GetGamesResponse>(result.Content);
-                var variants = response.Products?.Select(x => x.Variant).ToList();
-                products.AddRange(variants);
-                if (!variants.Any() || page == response.Pages)
+                var pageProducts = response.Products ?? new Product[0];
+                products.AddRange(pageProducts);
+                if (!pageProducts.Any() || page == response.Pages)
                 {
                     break;
                 }


### PR DESCRIPTION
## Summary
Fixes the JAST failed sync issue described in #765 

## Details
- update the JAST account response DTO to ignore the now-reference-only plural `variants` field and deserialize `game` from the containing product
- retain complete products while paging through the account library response
- map library entries from the embedded singular `variant` plus product-level `game` data
- preserve compatibility with the previous response layout by falling back to `variant.game`

## Root cause

JAST changed the authenticated library response around July 23, 2026. The plural `products[].variants` field now contains JSON-LD URI references such as `/api/v2/shop/product-variants/nnya033` instead of embedded variant objects. The existing DTO declared this field as `Variant[]`, so Newtonsoft.Json aborted with a `JsonSerializationException` before the library could be imported.

The same response update also moved `game` from the singular embedded `variant` to its containing product. Ignoring only the plural field would therefore deserialize successfully but later fail when mapping the game and translation data.

## User impact

JAST USA library synchronization currently fails for affected users on every attempt. This change accepts the updated response shape and restores game import while remaining compatible with the earlier nested-game shape.

## Validation

- rebuilt `JastUsaLibrary.csproj` successfully with MSBuild in Debug configuration
- deserialized a captured current JAST response containing 20 products (120 total across 6 pages); all products retained the required variant and game data
- verified a legacy response fixture still resolves `game` through the fallback path
- installed the Debug build into a Playnite 10 portable installation and completed a real authenticated JAST library sync successfully
- ran `git diff --check`

Fixes #765
